### PR TITLE
add: 光の時間の活動内容の削除機能の作成完了

### DIFF
--- a/app/controllers/light_times_controller.rb
+++ b/app/controllers/light_times_controller.rb
@@ -1,4 +1,7 @@
 class LightTimesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_light_time, only: [:show, :edit, :update, :destroy]
+
   def new
     @light_time = current_user.light_times.build
   end
@@ -12,16 +15,11 @@ class LightTimesController < ApplicationController
     end
   end
 
-  def show
-    @light_time = current_user.light_times.find(params[:id])
-  end
+  def show; end
 
-  def edit
-    @light_time = current_user.light_times.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @light_time = current_user.light_times.find(params[:id])
     if @light_time.update(light_time_params)
       redirect_to light_time_path(@light_time)
     else
@@ -29,7 +27,16 @@ class LightTimesController < ApplicationController
     end
   end
 
+  def destroy
+    @light_time.destroy!
+    redirect_to mypage_path, status: :see_other
+  end
+
   private
+
+  def set_light_time
+    @light_time = current_user.light_times.find(params[:id])
+  end
 
   def light_time_params
     params.require(:light_time).permit(:action, :desired_self, :characteristic)

--- a/app/views/light_times/show.html.erb
+++ b/app/views/light_times/show.html.erb
@@ -35,7 +35,7 @@
     <!-- 編集ボタン -->
     <div class="flex justify-center gap-10 text-center">
       <%= link_to "編集", edit_light_time_path(@light_time), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white font-semibold transition" %>
-      <%= link_to "削除", "#", class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white font-semibold transition" %>
+      <%= link_to "削除", light_time_path(@light_time), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white font-semibold transition" %>
     </div>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,5 @@ Rails.application.routes.draw do
   root "mypages#show" # ログイン後はマイページへ遷移
   resource :mypage, only: %i[show]
   resource :dark_time, only: %i[new create show edit update]
-  resources :light_times, only: %i[new create show edit update]
+  resources :light_times, only: %i[new create show edit update destroy]
 end


### PR DESCRIPTION
# 概要
光の時間の活動内容の削除機能の実装を行います。

- [x] destroyアクションのルーティングの設定を行っていることを確認しました。
- [x] light_timesコントローラーdestroyアクションの設定を行っていることを確認しました。
- [x] show.html.erbに削除ボタンのリンクを作成していることを確認しました。
- [x] 光の時間の活動内容詳細画面から「削除」をクリックすると、光の時間の活動内容が削除されてマイページへと遷移する。

追加の修正
- [x] light_timesコントローラーの@light_time取り出し処理のリファクタリングを行いました。認証後のみアクセスできるようにもしました。