### PR TITLE
add: タイマー画面にスタートボタンが表示されるように修正完了

### DIFF
--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -79,6 +79,7 @@ export default class extends Controller {
 
     this.updateTimeDisplay()
     this.showWorkScreen()
+    this.startButtonTarget.classList.remove("hidden")
     // ✅ チャイム音を再生
     this.playSound('/sounds/notification.mp3')
   }
@@ -90,7 +91,6 @@ export default class extends Controller {
 
     this.updateTimeDisplay()
     this.showBreakScreen()
-    // this.startButtonTarget.classList.add("hidden")
     // ✅ チャイム音を再生
     this.playSound('/sounds/notification.mp3')
     this.startTimer()


### PR DESCRIPTION
# 概要
https://github.com/TatsuhiroFuruta/get_the_time/pull/59 でタイマーのスタートボタンを追加し忘れていることを本番環境で確認したため、修正を行います。


- [x] ポモドーロタイマーで休憩時間終了後に、表示されるタイマー画面でスタートボタンが表示されることを確認しました。