### PR TITLE
add: ポモドーロタイマー機能：確認ダイアログの表示

### DIFF
--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -25,17 +25,15 @@ export default class extends Controller {
     // ✅ beforeunload イベントリスナーを追加
     this.boundBeforeUnloadHandler = this.handleBeforeUnload.bind(this)
 
-    // popstateイベントのリスナーを登録
-    this.boundBackHandler = this.handleBack.bind(this)
-
     this.updateTimeDisplay()
     this.updatePomodoroCount()
+
+    this.startButtonTarget.classList.remove("hidden")
   }
 
   disconnect() {
     // ✅ コントローラーが破棄される時にイベントリスナーを削除
     this.removeBeforeUnloadListener()
-    window.removeEventListener("popstate", this.boundBackHandler)
 
     if (this.timerInterval) {
       clearInterval(this.timerInterval)
@@ -58,9 +56,6 @@ export default class extends Controller {
       this.firstStartedAt = new Date()
       // ✅ 離脱警告を有効化
       this.addBeforeUnloadListener()
-      // ✅ 履歴エントリーを追加（戻るボタンを検知できるようにする）
-      history.pushState({ pomodoro: true }, "", location.href)
-      window.addEventListener("popstate", this.boundBackHandler)
     }
 
     if (this.mode === "work") {
@@ -102,6 +97,8 @@ export default class extends Controller {
 
   switchToWorkMode() {
     this.mode = "work"
+
+    this.endedAt = this.getEndedAt(new Date(), this.workDurationValue)
     this.remainingTime = this.workDurationValue
 
     this.updateTimeDisplay()
@@ -152,7 +149,7 @@ export default class extends Controller {
   // ✅ beforeunload イベントハンドラー
   handleBeforeUnload(event) {
     event.preventDefault()
-    // モダンブラウザでは戻り値は無視されますが、互換性のため設定
+    // モダンブラウザでは戻り値は無視されるが、互換性のため設定
     event.returnValue = ''
     return ''
   }
@@ -165,11 +162,6 @@ export default class extends Controller {
   // ✅ イベントリスナーを削除
   removeBeforeUnloadListener() {
     window.removeEventListener('beforeunload', this.boundBeforeUnloadHandler)
-  }
-
-  handleBack() {
-    alert("タイマー実行中は戻れません")
-    history.pushState({ pomodoro: true }, "", location.href)
   }
 
   // ✅ 音声を再生するメソッド

--- a/app/views/activity_records/pomodoro_timer.html.erb
+++ b/app/views/activity_records/pomodoro_timer.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="pomodoro" data-turbo="false" data-pomodoro-work-duration-value="120" data-pomodoro-break-duration-value="60" data-pomodoro-task-value="<%= @activity_record.task %>">
+<div data-controller="pomodoro" data-pomodoro-work-duration-value="120" data-pomodoro-break-duration-value="60" data-pomodoro-task-value="<%= @activity_record.task %>">
 
   <%= render "activity_records/pomodoro/work_screen" %>
 


### PR DESCRIPTION
# 概要
ポモドーロタイマー機能において、確認ダイアログの表示できるように実装を行います。

- [x] pomodoro_controller.jsに処理を作成していることを確認しました。

- [x] ポモドーロタイマー画面で最初の「スタート」クリック後、ブラウザリロード時、確認ダイアログが表示されることを確認しました。

- [x] ポモドーロタイマー画面以外の画面では、確認ダイアログが表示されないことを確認しました。

### 補足事項

- ブラウザの戻るボタンをクリックした時、マイページに戻り、ブラウザの進むボタンをクリックすると現状だとタイマーがリセットされます。その際に、スタートボタンが表示されていなかったため、表示できるようにしました。

- 途中、ブラウザの戻るボタンを押した際に、確認メッセージで戻るのかの検討もしくはアラート文を表示して戻るボタンのロックの実装を試みましたが、うまくいきませんでした。
### 具体的には、
- 確認メッセージで戻るのかの検討では、キャンセルをクリックしてもマイページに戻る
- アラート文を表示して戻るボタンのロックの実装では、文表示後にokをクリックすると、タイマーがリセットされる。再度、押すとアラート文が表示されるが、タイマーがリセットされない。3回目以降では、アラート文が表示されないといった原因が不明な事態となったため、実装を断念した