### PR TITLE
add: 光の時間の活動記録に検索機能の追加完了

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem "image_processing", "~> 1.2"
 # 認証を導入するため、deviseをインストール
 gem "devise"
 
+# 検索機能
+gem "ransack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
     rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
@@ -429,6 +433,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable
@@ -557,6 +562,7 @@ CHECKSUMS
   railties (8.1.2) sha256=1289ece76b4f7668fc46d07e55cc992b5b8751f2ad85548b7da351b8c59f8055
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835

--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -4,7 +4,9 @@ class ActivityRecordsController < ApplicationController
   before_action :set_activity_record, only: %i[show edit update destroy]
 
   def index
-    @activity_records = current_user.activity_records.includes(:light_time).order(created_at: :desc)
+    # @activity_records = current_user.activity_records.includes(:light_time).order(created_at: :desc)
+    @q = current_user.activity_records.ransack(params[:q])
+    @activity_records = @q.result(distinct: true).includes(:light_time).order(created_at: :desc)
   end
 
   def new

--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -10,4 +10,14 @@ class ActivityRecord < ApplicationRecord
     self.desired_self_percentage =
       (total_duration - idle_duration).to_f / total_duration
   end
+
+  # 検索可能カラムの登録
+  def self.ransackable_attributes(auth_object = nil)
+    ["comment"]  # 検索可能なカラム
+  end
+
+  # 検索可能な関連付けをホワイトリスト化
+  def self.ransackable_associations(auth_object = nil)
+    ["light_time"]
+  end
 end

--- a/app/models/light_time.rb
+++ b/app/models/light_time.rb
@@ -10,4 +10,8 @@ class LightTime < ApplicationRecord
       light_time.update!(is_current: true)
     end
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["action"]  # 検索可能なカラム
+  end
 end

--- a/app/views/activity_records/_search_form.html.erb
+++ b/app/views/activity_records/_search_form.html.erb
@@ -1,0 +1,6 @@
+<%= search_form_for q, url: url do |f| %>
+  <div class="flex gap-3 mb-10">
+    <%= f.search_field :comment_or_light_time_action_cont, placeholder: "コメント or 活動内容で検索", class: "flex-1 px-4 py-2 bg-gray-200 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    <%= f.submit '検索', class: "px-6 py-2 bg-blue-500 text-white font-bold rounded-lg hover:bg-blue-600 transition-colors" %>
+  </div>
+<% end %>

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -2,6 +2,12 @@
   <h1 class="text-2xl font-bold text-center mb-10 pt-10">
     光の時間の活動記録
   </h1>
+
+  <!-- 検索フォーム -->
+  <div class="max-w-2xl mx-auto">
+    <%= render 'search_form', q: @q, url: activity_records_path %>
+  </div>
+
   <% if @activity_records.present? %>
     <div class="max-w-2xl mx-auto">
       <!-- 一覧 -->


### PR DESCRIPTION
# 概要
光の時間の活動記録に検索機能の実装を行います。

- [x] ransack をbundle install でインストールを行いました。
- [x] _search_form.html.erbを生成し、検索フォームの作成を行いました。
- [x] LightTImeモデルとActivityRecordモデルの検索ワードと関連付けの設定を行いました。
- [x] 光の時間の行動内容もしくはコメントで検索できるのか確認しました。
- [x] 検索ワードの活動記録のみ表示されていることを確認しました。