### PR TITLE
fix: ハンバーガーメニュー：ルートパスアクセス時にもマイページのメニューが薄暗くなるように修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,6 +14,8 @@ module ApplicationHelper
     active = "bg-linear-to-b from-yellow-200 from-0% via-yellow-300 via-80% to-yellow-600 to-100%"
     inactive = "bg-yellow-200"
 
-    current_page?(path) ? "#{base} #{active}" : "#{base} #{inactive}"
+    is_active = current_page?(path) || (path == mypage_path && current_page?(root_path))
+
+    "#{base} #{is_active ? active : inactive}"
   end
 end


### PR DESCRIPTION
# 概要
ハンバーガーメニューにおいて、ルートパスアクセス時にもマイページのメニューが薄暗くなるように修正します。

- [x] ログイン後にハンバーガーメニューを開いたとき、マイページが薄暗く表示されていることを確認しました。
- [x]  `/` でアクセスしてハンバーガーメニューを開いたとき、マイページが薄暗く表示されていることを確認しました。