### PR TITLE
add: 浄化タイマーの時間付与機能の追加

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -22,6 +22,13 @@ class ActivityRecordsController < ApplicationController
     @form = ActivityRecordForm.new(activity_record_form_params)
 
     if @form.save(current_user)
+      minutes = ActivityRecord.calculate_purification_time(@form.total_duration)
+
+      # 0分のとき以外のみ追加！
+      if minutes > 0
+        flash[:purification_time] = "浄化タイマーを#{minutes}分獲得！"
+      end
+
       redirect_to activity_records_path
     else
       set_light_and_dark_times

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,5 +13,8 @@ application.register("hello", HelloController)
 import LightTimeSwitchController from "./light_time_switch_controller"
 application.register("light-time-switch", LightTimeSwitchController)
 
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
 import PomodoroController from "./pomodoro_controller"
 application.register("pomodoro", PomodoroController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ["overlay"]
+
+  connect() {
+    // モーダルが表示されたら自動的に呼ばれる
+    // モーダル表示時 → スクロール禁止
+    document.body.classList.add("overflow-hidden")
+  }
+
+  close() {
+    this.element.classList.add('opacity-0')
+
+    // スクロール解除
+    document.body.classList.remove("overflow-hidden")
+
+    setTimeout(() => {
+      this.element.style.display = 'none'
+    }, 300)
+  }
+
+  closeOnOverlay(event) {
+    // オーバーレイをクリックした時だけ閉じる
+    if (event.target === this.overlayTarget) {
+      this.close()
+    }
+  }
+}

--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -3,12 +3,17 @@ class ActivityRecord < ApplicationRecord
   belongs_to :light_time
 
   before_save :calculate_desired_self_percentage
+  after_create :grant_purification_time
 
-  def calculate_desired_self_percentage
-    return if total_duration.to_i == 0
+  # 浄化タイマーの時間計算メソッド
+  def self.calculate_purification_time(total_duration)
+    # return 0 if total_duration.blank? || total_duration < 10
+    return 0 if total_duration.blank? || total_duration < 1
 
-    self.desired_self_percentage =
-      (total_duration - idle_duration).to_f / total_duration
+    # 確認用
+    (total_duration / 2).floor * 1
+    # 本番用
+    # (total_duration / 30).floor * 10
   end
 
   # 検索可能カラムの登録
@@ -19,5 +24,28 @@ class ActivityRecord < ApplicationRecord
   # 検索可能な関連付けをホワイトリスト化
   def self.ransackable_associations(auth_object = nil)
     ["light_time"]
+  end
+
+  private
+
+  # 今日の本来の自分を算出メソッド
+  def calculate_desired_self_percentage
+    return if total_duration.to_i == 0
+
+    self.desired_self_percentage = (total_duration - idle_duration).to_f / total_duration
+  end
+
+  # 浄化タイマーの時間を付与するメソッド
+  def grant_purification_time
+    minutes = self.class.calculate_purification_time(total_duration)
+    return if minutes <= 0
+
+    user.with_lock do
+      purification_time = user.purification_time || user.build_purification_time
+
+      purification_time.remaining_time += minutes
+
+      purification_time.save!
+    end
   end
 end

--- a/app/models/purification_time.rb
+++ b/app/models/purification_time.rb
@@ -1,0 +1,5 @@
+class PurificationTime < ApplicationRecord
+  belongs_to :user
+
+  enum :status, { idle: 0, running: 1, paused: 2, completed: 3 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   has_one :dark_time, dependent: :destroy
   has_many :light_times, dependent: :destroy
   has_many :activity_records, dependent: :destroy
+  has_one :purification_time, dependent: :destroy
 end

--- a/app/views/activity_records/_grant_purification_time_modal.html.erb
+++ b/app/views/activity_records/_grant_purification_time_modal.html.erb
@@ -1,0 +1,25 @@
+<% if flash[:purification_time] %>
+  <div data-controller="modal" class="fixed inset-0 z-70 flex items-center justify-center transition-opacity duration-300">
+
+    <!-- オーバーレイ -->
+    <div
+      data-modal-target="overlay"
+      data-action="click->modal#closeOnOverlay"
+      class="absolute inset-0 bg-black opacity-50">
+    </div>
+
+    <!-- モーダル本体 -->
+    <div class="relative bg-linear-to-b from-blue-800 from-0% via-sky-400 via-80% to-blue-50 to-100% p-6 rounded-xl text-center z-10 w-80 aspect-square flex flex-col justify-center items-center">
+      <p class="text-white mb-2">
+        <%= flash[:purification_time] %>
+      </p>
+
+      <%= image_tag "timer.png", class: "w-32 my-4" %>
+
+      <button data-action="click->modal#close" class="bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 transition px-6 py-2 rounded-full">
+        OK
+      </button>
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -1,5 +1,8 @@
 <div class="min-h-screen bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
 
+  <!-- 浄化タイマーの時間付与時に表示されるモーダル -->
+  <%= render "activity_records/grant_purification_time_modal" %>
+
   <!-- ハンバーガーメニュー -->
   <%= render "shared/hamburger_menu" %>
 

--- a/db/migrate/20260331055407_create_purification_times.rb
+++ b/db/migrate/20260331055407_create_purification_times.rb
@@ -1,0 +1,14 @@
+class CreatePurificationTimes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :purification_times do |t|
+      t.integer :status
+      t.integer :remaining_time
+      t.integer :total_time
+      t.datetime :started_at
+      t.datetime :paused_at
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260331074958_add_default_to_purification_times.rb
+++ b/db/migrate/20260331074958_add_default_to_purification_times.rb
@@ -1,0 +1,9 @@
+class AddDefaultToPurificationTimes < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :purification_times, :remaining_time, 0
+    change_column_default :purification_times, :total_time, 0
+
+    change_column_null :purification_times, :remaining_time, false
+    change_column_null :purification_times, :total_time, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_11_052422) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_31_074958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,6 +56,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_052422) do
     t.index ["user_id"], name: "index_light_times_on_user_id"
   end
 
+  create_table "purification_times", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "paused_at"
+    t.integer "remaining_time", default: 0, null: false
+    t.datetime "started_at"
+    t.integer "status"
+    t.integer "total_time", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_purification_times_on_user_id", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -73,4 +85,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_11_052422) do
   add_foreign_key "activity_records", "users"
   add_foreign_key "dark_times", "users"
   add_foreign_key "light_times", "users"
+  add_foreign_key "purification_times", "users"
 end


### PR DESCRIPTION
# 概要
光の時間の活動記録の新規登録後に浄化タイマーの時間が付与されることを通知する機能の実装を行います。

- [x] マイグレーション、モデルの生成 (PurificationTimeモデル)を行いました。
- [x] ActivityRecordモデルに浄化タイマーの時間算出メソッド及び時間付与メソッドを記述しました。
- [x] activity_recordsコントローラーのcreateアクションに獲得した時のメッセージを取得できるように記述しました。
- [x] modal_controller.jsに時間通知の処理を記述しました。
- [x] 活動記録新規登録後、30分毎に10分の浄化タイマーが付与の通知画面がモーダル画面で表示されていることを確認しました。
- [x] 活動記録新規登録後に浄化タイマーが付与されない場合、通知画面がモーダル画面で表示されないことを確認しました。
### 補足事項
以下は次のissue #35 で実行
- マイページに浄化タイマーを表示する箇所を表示し、浄化タイマーの時間が更新されていることを確認しました。
