### PR TITLE
WIP: 途中で断念：活動記録でブラウザの戻るボタンや記録しない場合のみの処理のみ未作成

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,8 @@
+class ActivitiesController < ApplicationController
+  before_action :authenticate_user!
+
+  def cancel
+    current_user.update!(current_mode: :idle)
+    head :ok
+  end
+end

--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -2,6 +2,7 @@ class ActivityRecordsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_light_and_dark_times, only: %i[new create]
   before_action :set_activity_record, only: %i[show edit update destroy]
+  before_action :ensure_can_start_activity, only: %i[pomodoro_timer]
 
   def index
     # @activity_records = current_user.activity_records.includes(:light_time).order(created_at: :desc)
@@ -22,6 +23,7 @@ class ActivityRecordsController < ApplicationController
     @form = ActivityRecordForm.new(activity_record_form_params)
 
     if @form.save(current_user)
+      current_user.update!(current_mode: :idle)
       minutes = ActivityRecord.calculate_purification_time(@form.total_duration)
 
       # 0分のとき以外のみ追加！
@@ -58,6 +60,7 @@ class ActivityRecordsController < ApplicationController
     @activity_record = current_user.activity_records.build(task: params.permit(:task)[:task])
     @light_time = current_user.light_times.find_by(is_current: true)
     @dark_time = current_user.dark_time
+    current_user.update_column(:current_mode, "activity")
   end
 
   private
@@ -86,5 +89,12 @@ class ActivityRecordsController < ApplicationController
     :idle_duration, :satisfaction, :progress,
     :quality, :focus, :fatigue, :comment
     )
+  end
+
+  def ensure_can_start_activity
+    return if current_user.can_start_activity?
+    Rails.logger.debug "current_mode: #{current_user.current_mode}"
+    redirect_to mypage_path, alert: "タイマー実行中です"
+    return
   end
 end

--- a/app/controllers/purification_times_controller.rb
+++ b/app/controllers/purification_times_controller.rb
@@ -1,16 +1,19 @@
 class PurificationTimesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_purification_time
+  before_action :ensure_can_start_purification, only: %i[start]
 
   def show; end
 
   def start
     @purification_time.start!
+    current_user.update!(current_mode: :purification)
     head :ok
   end
 
   def stop
     @purification_time.stop!
+    current_user.update!(current_mode: :idle)
     head :ok
   end
 
@@ -23,5 +26,11 @@ class PurificationTimesController < ApplicationController
 
   def set_purification_time
     @purification_time = current_user.purification_time
+  end
+
+  def ensure_can_start_purification
+    return if current_user.can_start_purification?
+    redirect_to mypage_path, alert: "タイマー実行中です"
+    return
   end
 end

--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -45,6 +45,12 @@ export default class extends Controller {
     this.updateUI()
 
     this.startButtonTarget.classList.remove("hidden")
+
+    this.isNavigatingToForm = false
+
+    // this.isNavigatingToForm = localStorage.getItem("navigatingToForm") === "true"
+
+    // localStorage.removeItem("navigatingToForm")
   }
 
   disconnect() {
@@ -53,6 +59,12 @@ export default class extends Controller {
 
     if (this.timerInterval) {
       clearInterval(this.timerInterval)
+    }
+
+    console.log(this.isNavigatingToForm)
+
+    if (!this.isNavigatingToForm) {
+      this.cancelActivity()
     }
   }
 
@@ -262,6 +274,8 @@ export default class extends Controller {
     )
 
     if (confirmed) {
+      this.isNavigatingToForm = true
+      // localStorage.setItem("navigatingToForm", "true")
       window.location.replace(`/activity_records/new?${params.toString()}`)
     } else {
       // キャンセルされた場合は、タイマーをリセット
@@ -326,6 +340,8 @@ export default class extends Controller {
     if (this.firstStartedAt) {
       // ✅ 最初のスタート時刻からの差分を計算
       const params = this.saveActivityRecord(lastEndedAt)
+      this.isNavigatingToForm = true
+      // localStorage.setItem("navigatingToForm", "true")
       // ✅ 確認フォーム画面に遷移
       window.location.replace(`/activity_records/new?${params.toString()}`)
     } else {
@@ -346,5 +362,14 @@ export default class extends Controller {
       'activity_record_form[total_duration]': durationInMinutes
     })
     return params
+  }
+
+  cancelActivity() {
+    fetch("/activity/cancel", {
+      method: "POST",
+      headers: {
+        "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
+      }
+    })
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,14 @@ class User < ApplicationRecord
   has_many :light_times, dependent: :destroy
   has_many :activity_records, dependent: :destroy
   has_one :purification_time, dependent: :destroy
+
+  enum :current_mode, { idle: 0, purification: 1, activity: 2 }
+
+  def can_start_purification?
+    idle?
+  end
+
+  def can_start_activity?
+    idle?
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,6 @@ Rails.application.routes.draw do
     patch :stop
     patch :reset
   end
+
+  post "activity/cancel", to: "activities#cancel"
 end

--- a/db/migrate/20260404062121_add_current_mode_column_to_user.rb
+++ b/db/migrate/20260404062121_add_current_mode_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddCurrentModeColumnToUser < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :current_mode, :integer, default: 0, null: false
+  end
+end


### PR DESCRIPTION
# 概要
光の時間のポモドーロタイマー及び活動記録登録、浄化タイマーへのアクセス権の設定について行う予定でしたが、途中で断念しました。ただ、コードの変更内容を記録しておきます。

- 浄化タイマーや光の時間の活動のポモドーロタイマーでどちらかのみアクセスできることは確認できました
- しかしながら、開発の途中で活動記録でブラウザの戻るボタンや記録しない場合の処理を対処しないといけないことに気づきました
- その場合、設定が複雑になるのと同時にUserモデルのcurrent_modeカラムを頻繁に更新することでDBに負荷がかかってしまうという問題点が生じてしまいます。
- 他の方法についても検討を行いましたが、それでも複雑になってしまうことが想定されました。
- そのため、コードの内容のみ記録し、現状のMVP開発においては断念する判断としました。（マージせず、ブランチを残します）