### PR TITLE
fix: ホーム画面の文章の改行を防ぐためにpaddingを小さく調整

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -13,7 +13,7 @@
     </div> %>
   </div>
   <main class="relative top-10 h-screen w-full flex items-center justify-center bg-center bg-[url('grab_the_light.png')]">
-    <div class="mx-auto bg-stone-300/67 rounded-3xl shadow-2xl p-10 w-120 text-center text-zinc-800">
+    <div class="mx-auto bg-stone-300/67 rounded-3xl shadow-2xl p-8 w-120 text-center text-zinc-800">
       <!-- タイトル -->
       <div class="text-3xl text-center font-semibold mb-6">
         Get The Time<br>


### PR DESCRIPTION
本番環境において、ホーム画面の文章の改行を防ぐためにpaddingを小さく調整を行う