### PR TITLE
fix: スマホ画面に対応できるように調整

### DIFF
--- a/app/views/activity_records/edit.html.erb
+++ b/app/views/activity_records/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
-  <div class="w-full max-w-2xl py-10">
+  <div class="w-80 md:w-full max-w-2xl py-10">
 
     <!-- タイトル -->
     <h1 class="text-center text-xl font-bold mb-2">

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -11,12 +11,12 @@
   </h1>
 
   <!-- 検索フォーム -->
-  <div class="max-w-xl mx-auto">
+  <div class="w-80 md:w-full max-w-xl mx-auto">
     <%= render 'search_form', q: @q, url: activity_records_path %>
   </div>
 
   <% if @activity_records.present? %>
-    <div class="max-w-2xl mx-auto">
+    <div class="w-80 md:w-full max-w-2xl mx-auto">
       <!-- 一覧 -->
       <div class="space-y-4">
         <%= render @activity_records %>

--- a/app/views/activity_records/new.html.erb
+++ b/app/views/activity_records/new.html.erb
@@ -1,5 +1,5 @@
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
-  <div class="w-full max-w-2xl py-10">
+  <div class="w-80 md:w-full max-w-2xl py-10">
 
     <!-- タイトル -->
     <h1 class="text-center text-xl font-bold mb-2">

--- a/app/views/activity_records/pomodoro/_break_screen.html.erb
+++ b/app/views/activity_records/pomodoro/_break_screen.html.erb
@@ -4,7 +4,7 @@
     <%= render "activity_records/pomodoro/timer_display" %>
   </div>
 
-  <%= image_tag "timer.png", class: "w-100 my-6" %>
+  <%= image_tag "timer.png", class: "w-80 md:w-100 my-6" %>
 
   <%= render "activity_records/pomodoro/motivation_button" %>
 

--- a/app/views/activity_records/pomodoro/_task_input.html.erb
+++ b/app/views/activity_records/pomodoro/_task_input.html.erb
@@ -13,7 +13,7 @@
 
     <input type="text" data-pomodoro-target="taskInput" placeholder="やることを入力" class="rounded px-3 py-2 w-48 bg-gray-200 border-2 focus:outline-none focus:ring-4 focus:ring-blue-400">
 
-    <button data-action="click->pomodoro#updateTaskDisplay" class="bg-green-700 text-white/90 px-6 py-2 rounded-full hover:bg-green-800 transition duration-200">
+    <button data-action="click->pomodoro#updateTaskDisplay" class="bg-green-700 text-white/90 text-xs md:text-base px-4 md:px-6 py-2 rounded-full hover:bg-green-800 transition duration-200">
       更新する
     </button>
 

--- a/app/views/activity_records/pomodoro/_timer_buttons.html.erb
+++ b/app/views/activity_records/pomodoro/_timer_buttons.html.erb
@@ -1,10 +1,10 @@
 <div class="flex justify-center gap-6">
 
-  <button type="button" data-pomodoro-target="startButton" data-action="click->pomodoro#start" class="bg-green-700 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-green-800 transition duration-200">
+  <button type="button" data-pomodoro-target="startButton" data-action="click->pomodoro#start" class="bg-green-700 text-white/90 px-6 py-2 rounded-full hover:bg-green-800 transition duration-200">
     スタート
   </button>
 
-  <button type="submit" data-action="click->pomodoro#finish" class="bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200">
+  <button type="submit" data-action="click->pomodoro#finish" class="bg-red-500 text-white/90 px-6 py-2 rounded-full hover:bg-red-600 transition duration-200">
     終了する
   </button>
 

--- a/app/views/dark_times/_form.html.erb
+++ b/app/views/dark_times/_form.html.erb
@@ -38,9 +38,9 @@
   </div>
 
   <!-- ボタン -->
-  <div class="flex justify-center gap-10 pt-6">
-    <%= f.submit button_text, class: "#{button_class} px-8 py-2 rounded-full text-white/90 text-lg transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-8 py-2 rounded-full bg-red-500 text-white/90 text-lg hover:bg-red-600 transition duration-200 shadow-md" %>
+  <div class="flex justify-center gap-6 pt-6">
+    <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
+    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/light_times/_form.html.erb
+++ b/app/views/light_times/_form.html.erb
@@ -33,9 +33,9 @@
   </div>
 
   <!-- ボタン -->
-  <div class="flex justify-center gap-10 pt-6">
-    <%= f.submit button_text, class: "#{button_class} px-8 py-2 rounded-full text-white/90 text-lg transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-8 py-2 rounded-full bg-red-500 text-white/90 text-lg hover:bg-red-600 transition duration-200 shadow-md" %>
+  <div class="flex justify-center gap-6 pt-6">
+    <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
+    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/light_times/show.html.erb
+++ b/app/views/light_times/show.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <!-- 光の時間の特徴 -->
-    <div class="mb-16">
+    <div class="mb-12">
       <p class="mb-2 text-sm">光の時間の特徴</p>
       <div class="bg-amber-500 rounded-lg px-6 py-4">
         <%= @light_time.characteristic.presence || "これから見つけていく" %>

--- a/app/views/mypages/_dark_time.html.erb
+++ b/app/views/mypages/_dark_time.html.erb
@@ -1,27 +1,27 @@
 <% if dark_time.present? %>
-  <div class="w-80 flex justify-center">
-    <%= link_to dark_time_path, class: "block w-full flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% rounded-3xl shadow-2xl p-10 text-white/90" do %>
+  <div class="w-50 md:w-80 flex justify-center">
+    <%= link_to dark_time_path, class: "block w-full flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% rounded-3xl shadow-2xl p-2 md:p-10 text-white/90" do %>
       <div class="mb-4 p-4 rounded-xl text-center">
         <p class="text-sm mb-1">
           闇の時間での行動
         </p>
-        <p class="font-semibold  bg-violet-800 px-1 py-4 rounded-2xl">
+        <p class="font-semibold  bg-violet-800 px-1 py-2 md:py-4 rounded-2xl text-sm md:text-base">
           <%= dark_time.behavior %>
         </p>
 
         <p class="text-sm mt-3 mb-1">
           避けたい未来
         </p>
-        <p class="font-semibold  bg-violet-800 px-1 py-4 rounded-2xl">
+        <p class="font-semibold  bg-violet-800 px-1 py-2 md:py-4 rounded-2xl text-sm md:text-base">
           <%= dark_time.unwanted_future.presence || "これから考える" %>
         </p>
       </div>
     <% end %>
   </div>
 <% else %>
-  <div class="flex items-center justify-center bg-stone-300/67 rounded-3xl shadow-2xl p-10 w-80 text-center text-white/90">
+  <div class="flex items-center justify-center bg-stone-300/67 rounded-3xl shadow-2xl p-6 md:p-10 w-50 md:w-80 text-center text-white/90">
     <div>
-      <p class="mb-8 text-lg leading-relaxed">
+      <p class="mb-4 md:mb-8 text-sm md:text-lg leading-relaxed">
         闇の時間での行動が<br>
         登録されていません<br>
         新規登録しましょう

--- a/app/views/mypages/_light_time.html.erb
+++ b/app/views/mypages/_light_time.html.erb
@@ -1,7 +1,7 @@
 <% light_times = current_user.light_times.order(:created_at).pluck(:id) %>
 
 <% if light_time.present? %>
-  <div id="light-time-switch" data-controller="light-time-switch" data-light_times="<%= light_times.to_json %>" data-current-id="<%= @light_time.id %>">
+  <div id="light-time-switch" data-controller="light-time-switch" data-light_times="<%= light_times.to_json %>" data-current-id="<%= @light_time.id %>" class="flex flex-col items-center gap-6 md:block">
     <div class="flex flex-row md:flex-col items-center justify-center gap-6 text-zinc-800">
 
       <% if light_times.size > 1 %>
@@ -11,19 +11,19 @@
       <% end %>
 
       <!-- 固定幅コンテナ -->
-      <div class="w-80 flex justify-center">
-        <%= link_to light_time_path(light_time), class: "block w-full flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-3xl shadow-2xl p-10" do %>
+      <div class="w-50 md:w-80 flex justify-center">
+        <%= link_to light_time_path(light_time), class: "block w-full flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-3xl shadow-2xl p-2 md:p-10" do %>
           <div class="mb-4 p-4 rounded-xl text-center">
-            <p class="text-sm mb-1">
+            <p class="text-xs md:text-sm mb-1">
               光の時間での行動
             </p>
-            <p class="font-semibold  bg-amber-500 px-1 py-4 rounded-2xl">
+            <p class="font-semibold bg-amber-500 px-1 py-2 md:py-4 rounded-2xl text-sm md:text-base">
               <%= light_time.action %>
             </p>
             <p class="text-sm mt-3 mb-1">
               なりたい自分
             </p>
-            <p class="font-semibold  bg-amber-500 px-1 py-4 rounded-2xl">
+            <p class="font-semibold bg-amber-500 px-1 py-2 md:py-4 rounded-2xl text-sm md:text-base">
               <%= light_time.desired_self.presence || "まだ見ぬ可能性に満ちた新しい自分に出会うため" %>
             </p>
           </div>
@@ -37,11 +37,19 @@
       <% end %>
 
     </div>
+
+    <!-- スマホ対応画面における新規登録ボタン -->
+    <% if both_times_present?(dark_time, light_time) %>
+      <div class="md:hidden">
+        <%= link_to "新規登録", new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+      </div>
+    <% end %>
+
   </div>
 <% else %>
-  <div class="flex items-center justify-center bg-stone-300/67 rounded-3xl shadow-2xl p-10 w-80 text-center">
+  <div class="flex items-center justify-center bg-stone-300/67 rounded-3xl shadow-2xl p-6 md:p-10 w-50 md:w-80 text-center">
     <div>
-      <p class="mb-8 text-lg leading-relaxed">
+      <p class="mb-4 md:mb-8 text-sm md:text-lg leading-relaxed">
         光の時間での行動が<br>
         登録されていません<br>
         新規登録しましょう

--- a/app/views/mypages/_pomodoro_start.html.erb
+++ b/app/views/mypages/_pomodoro_start.html.erb
@@ -8,7 +8,7 @@
     <%= format_minutes_to_hm(@today_light_time) %>
   </p>
 
-  <p class="mb-2">
+  <p class="mb-2 text-white/90 md:text-zinc-800">
     やること(任意)
   </p>
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center">
+<div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
 
   <!-- 🔹 ハンバーガーメニュー -->
   <% if both_times_present?(@dark_time, @light_time) %>
@@ -7,36 +7,36 @@
 
   <!-- 🔹 右上ユーザーメニュー -->
   <div class="flex justify-end px-6 pt-6">
-    <div class="flex gap-6">
+    <div class="flex gap-3 md:gap-6">
 
       <% if both_times_present?(@dark_time, @light_time) %>
-        <div class="flex items-center justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
+        <div class="hidden md:flex items-center justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
           <%= link_to "新規登録", new_light_time_path, class: "w-full text-xs text-center text-zinc-800 inline-block py-1 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
         </div>
       <% end %>
 
       <% if @purification_time %>
-        <div data-controller="purification-timer" class="bg-linear-to-b from-blue-800 from-0% via-sky-400 via-80% to-blue-50 to-100% rounded-2xl px-4 py-3 shadow-xl w-40 h-40 text-white/90">
+        <div data-controller="purification-timer" class="flex flex-col items-center justify-center md:block bg-linear-to-b from-blue-800 from-0% via-sky-400 via-80% to-blue-50 to-100% rounded-2xl px-2 md:px-4 py-1 md:py-3 shadow-xl w-30 md:w-40 h-30 md:h-40 text-white/90">
 
           <div class="flex items-center justify-center gap-3 mb-3">
-            <%= image_tag "timer.png", class: "w-8" %>
+            <%= image_tag "timer.png", class: "hidden md:inline w-8" %>
 
-            <div class="text-sm text-center">
+            <div class="text-xs md:text-sm text-center">
               浄化タイマー
             </div>
           </div>
 
           <% if @purification_time.running? %>
-            <%= link_to "実行中", purification_time_path, class: "block text-xs bg-green-700 text-center rounded-full py-1 my-11 hover:bg-green-800 transition duration-200" %>
+            <%= link_to "実行中", purification_time_path, class: "w-full block text-xs bg-green-700 text-center rounded-full py-1 md:my-11 hover:bg-green-800 transition duration-200" %>
           <% else %>
-            <div class="text-sm text-center mb-3">
+            <div class="hidden md:block text-sm text-center mb-3">
               <%= format_seconds_to_mmss(@purification_time&.remaining_time.to_i) %>
             </div>
 
             <% if @purification_time.finished? %>
-              <%= link_to "メッセージ", purification_time_path, class: "block text-xs bg-green-700 text-center rounded-full py-1 mb-2 hover:bg-green-800 transition duration-200" %>
+              <%= link_to "メッセージ", purification_time_path, class: "w-full block text-xs bg-green-700 text-center rounded-full py-1 md:mb-2 hover:bg-green-800 transition duration-200" %>
             <% else %>
-              <%= link_to "スタート", purification_time_path, class: "block text-xs bg-green-700 text-center rounded-full py-1 mb-2 hover:bg-green-800 transition duration-200" %>
+              <%= link_to "スタート", purification_time_path, class: "w-full block text-xs bg-green-700 text-center rounded-full py-1 mb-2 hover:bg-green-800 transition duration-200" %>
               <button type="button" data-action="click->purification-timer#reset" class="w-full text-xs text-center bg-red-500 rounded-full py-1 hover:bg-red-600 transition duration-200">
                 リセット
               </button>
@@ -45,12 +45,12 @@
         </div>
       <% end %>
 
-      <div class="flex flex-col items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl px-4 py-3 shadow-xl w-40">
-        <div class="text-sm text-center text-zinc-800 font-semibold mb-4">
+      <div class="flex flex-col items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl px-2 md:px-4 py-1 md:py-3 shadow-xl w-30 md:w-40">
+        <div class="text-xs md:text-sm text-center text-zinc-800 font-semibold mb-3 md:mb-4">
           <%= current_user.name || "ユーザーA" %>
         </div>
 
-        <%= link_to "使い方", how_to_use_path, class: "w-full block text-xs bg-amber-500 text-zinc-800 text-center rounded-full py-1 mb-2 hover:bg-amber-600 transition duration-200" %>
+        <%= link_to "使い方", how_to_use_path, class: "w-full text-xs bg-amber-500 text-zinc-800 text-center rounded-full py-1 mb-2 hover:bg-amber-600 transition duration-200" %>
 
         <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete },  class: "w-full text-xs text-center bg-red-500 text-white/90 rounded-full py-1 hover:bg-red-600 transition duration-200" %>
       </div>
@@ -58,7 +58,7 @@
   </div>
 
   <!-- 🔹 メインエリア -->
-  <div class="flex items-center justify-center min-h-screen px-10">
+  <div class="flex items-start md:items-center justify-center min-h-screen px-10">
     <div class="flex flex-col-reverse my-10 md:my-0 md:flex-row items-center justify-center <%= both_times_present?(@dark_time, @light_time) ? 'gap-20' : 'gap-40 md:gap-80' %>">
 
       <!-- 🌑 闇側カード -->
@@ -70,7 +70,7 @@
       <% end %>
 
       <!-- ☀ 光側カード -->
-      <%= render "light_time", light_time: @light_time %>
+      <%= render "light_time", light_time: @light_time, dark_time: @dark_time %>
 
     </div>
   </div>

--- a/app/views/purification_times/show.html.erb
+++ b/app/views/purification_times/show.html.erb
@@ -3,7 +3,7 @@
   data-purification-timer-remaining-value="<%= @purification_time.remaining_time %>"
   data-purification-timer-started-at-value="<%= @purification_time.started_at&.to_i %>"
   data-purification-timer-running-value="<%= @purification_time.running? %>"
-  class=" min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-800 from-0% via-sky-400 via-80% to-blue-50 to-100%"
+  class="min-h-screen flex flex-col items-center justify-center bg-linear-to-b from-blue-800 from-0% via-sky-400 via-80% to-blue-50 to-100%"
 >
   <!-- タイマー表示 -->
   <div class="text-white/90">
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <%= image_tag "timer.png", class: "w-100 my-12" %>
+  <%= image_tag "timer.png", class: "w-80 md:w-100 my-12" %>
 
   <!-- ボタン -->
 
@@ -34,13 +34,13 @@
     </div>
   <% elsif @purification_time.idle? || @purification_time.paused? %>
   <div class="flex justify-center gap-6">
-      <button type="button" data-action="click->purification-timer#start" class="bg-green-700 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-green-800 transition duration-200">
+      <button type="button" data-action="click->purification-timer#start" class="bg-green-700 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-green-800 transition duration-200">
           スタート
         </button>
-        <%= link_to "キャンセル", mypage_path, class: "bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
+        <%= link_to "キャンセル", mypage_path, class: "bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
       </div>
   <% elsif @purification_time.running? %>
-    <button type="button" data-action="click->purification-timer#stop" class="bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200">
+    <button type="button" data-action="click->purification-timer#stop" class="bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200">
       終了する
     </button>
   <% end %>

--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <!-- ハンバーガーメニュー展開時 -->
-    <nav data-hamburger-target="menu" class="fixed top-0 left-0 h-full w-1/3 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% z-50 transform -translate-x-full transition-transform duration-300">
+    <nav data-hamburger-target="menu" class="fixed top-0 left-0 h-full w-1/2 md:w-1/3 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% z-50 transform -translate-x-full transition-transform duration-300">
       <ul class="pt-35 last:border-b last:border-amber-500">
         <li><%= link_to "マイページ", mypage_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mypage_path) %></li>
         <li><%= link_to "活動記録", activity_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(activity_records_path) %></li>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,44 +1,44 @@
 <!-- ヘッダー -->
 <nav class="fixed top-0 w-full z-50 px-6 py-4 flex justify-between items-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
-  <%= link_to "Get The Time", root_path, class: "inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-4 py-2 rounded-lg" %>
+  <%= link_to "Get The Time", root_path, class: "inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div>
-    <%= link_to "新規登録", new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
-    <%= link_to "ログイン", new_user_session_path, class: "ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+    <%= link_to "新規登録", new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
+    <%= link_to "ログイン", new_user_session_path, class: "ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
   </div>
 </nav>
 
 <!-- メインコンテンツ -->
-<main class="relative top-10 h-screen w-full flex items-center justify-center bg-center bg-[url('grab_the_light.png')]">
-  <div class="mx-auto bg-stone-300/67 rounded-3xl shadow-2xl p-8 w-120 text-center text-zinc-800">
+<main class="relative top-10 min-h-screen w-full flex items-center justify-center bg-center bg-[url('grab_the_light.png')]">
+  <div class="mx-auto bg-stone-300/67 rounded-3xl shadow-2xl p-2 md:p-8 w-80 md:w-120 text-center text-zinc-800">
     <!-- タイトル -->
-    <div class="text-3xl text-center font-semibold mb-6">
+    <div class="text-3xl text-center font-semibold mb-3 md:mb-6">
       Get The Time<br>
       <span class="text-lg">- 本来の自分を手に入れろ -</span>
     </div>
 
-    <div class="text-md leading-relaxed">
+    <div class="text-xs md:text-base leading-relaxed">
       読書や勉強など、本来やりたいことがあったのに、<br>
       SNSや動画コンテンツ等をつい見てしまって<br>
       後悔する1日を過ごしてしまった
     </div>
 
-    <div class="text-xl font-semibold my-6">こうした日常を解消しませんか？</div>
+    <div class="text-lg md:text-xl font-semibold my-3 md:my-6">こうした日常を解消しませんか？</div>
 
-    <div class="text-md leading-relaxed">
+    <div class="text-xs md:text-base leading-relaxed">
       自分が本来やりたいと思った行動を<strong>光の時間での行動</strong>、<br>
       後悔の原因となる行動を<strong>闇の時間での行動</strong>として考え、<br>
       光の時間での行動を実際に行い、記録していくことで<br>
       <strong>本来の自分と向き合うサービス</strong>です。
     </div>
 
-    <div class="text-xl font-semibold my-6">
+    <div class="text-lg md:text-xl font-semibold my-3 md:my-6">
       光の時間をできるだけ掴み取り<br>
       本来の自分を取り戻せ！
     </div>
 
     <div class="flex justify-center items-center gap-6">
-      <%= link_to "はじめる", new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
-      <%= link_to "ログイン", new_user_session_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+      <%= link_to "はじめる", new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
+      <%= link_to "ログイン", new_user_session_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
     </div>
   </div>
 </main>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -4,7 +4,8 @@
     <%= link_to "← マイページに戻る", mypage_path, class: "fixed top-6 left-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
   <!-- メインコンテンツ -->
   <main class= "flex flex-col items-center">
-    <div class="w-full max-w-2xl mt-30">
+    <div class="w-80 md:w-full max-w-2xl mt-30">
+      <%= render "static_pages/how_to_use/abstract" %>
       <%= render "static_pages/how_to_use/step1" %>
       <%= render "static_pages/how_to_use/step2" %>
       <%= render "static_pages/how_to_use/step3" %>

--- a/app/views/static_pages/how_to_use/_abstract.html.erb
+++ b/app/views/static_pages/how_to_use/_abstract.html.erb
@@ -1,0 +1,26 @@
+<div>
+  <h1 class="font-bold text-3xl mb-6">概要</h1>
+  <p class="text-lg leading-relaxed">Get The Time は本来望んでいる行動を<strong>光の時間の行動</strong>、
+    望んでいないついやってしまう行動を<strong>闇の時間の行動</strong>として考えて、
+    光の時間の行動をすることで、本来の自分を取り戻すサービスです。具体的には、まず
+  </p>
+  <p class="font-bold text-xl my-2">Step1: 闇の時間の活動内容の登録</p>
+  <p class="text-lg leading-relaxed">で闇の時間での行動を言語化し、その行動し続けることで迎えてしまう避けたい未来を想像していただきます。</p>
+  <p class="text-lg leading-relaxed">次に</p>
+  <p class="font-bold text-xl my-2">Step2: 光の時間の活動内容の登録</p>
+  <p class="text-lg leading-relaxed">で、光の時間での行動の言語化してもらうと同時に、なりたい自分について明確にします。</p>
+  <p class="text-lg leading-relaxed">上記の2ステップで各々の行動と導かれる未来を認識した後に、実際に光の時間の行動に記載した活動に取り組んでいただきます。</p>
+  <p class="text-lg leading-relaxed">具体的には、</p>
+  <p class="font-bold text-xl my-2">Step3: 光の時間の活動時間の計測</p>
+  <p class="font-bold text-xl my-2">Step4: 光の時間の活動記録の登録</p>
+  の2ステップを通して、ポモドーロタイマーを用いて活動を行い、活動記録として記録することで振り返りを行います。
+  最後に
+  <p class="font-bold text-xl my-2">Step5: 浄化タイマーの使い方</p>
+  の説明を行っております。
+  浄化タイマーとは、闇の時間での行動（娯楽時間）やリラックスする残り時間をカウントするタイマーのことです。
+  浄化タイマーの時間は、光の時間の活動記録登録後に時間が付与されます。
+  浄化タイマーを活用することで、娯楽時間の目安を把握することができ、
+  光の時間と闇の時間のバランスをとって過ごすことができます。
+  結果的に、「やるべきことをやらないといけないのは分かっているけど、遊ぶ時間は欲しい。
+  けど、どのくらいとって大丈夫なのか分からない」といった悩みが解消されます。
+</div>

--- a/app/views/static_pages/how_to_use/_step1.html.erb
+++ b/app/views/static_pages/how_to_use/_step1.html.erb
@@ -11,7 +11,7 @@
     <%= image_tag "how_to_use/mypage_dark_time_new_path.png" %>
   </div>
   <div class="my-6">
-    <p class="mb-2 text-lg">3. 闇の時間での行動を登録</p>
+    <p class="mb-2 text-lg">3. 闇の時間での行動（やりたくないけどついやってしまうこと、本来望んでいる行動に対して時間泥棒の原因になること）を登録</p>
     <p class="mb-2 text-md">
       ※ 避けたい未来や闇の時間の特徴について、見つかっていない場合は無理に埋めなくても大丈夫です。
     </p>

--- a/app/views/static_pages/how_to_use/_step2.html.erb
+++ b/app/views/static_pages/how_to_use/_step2.html.erb
@@ -11,7 +11,7 @@
     <%= image_tag "how_to_use/mypage_light_time_new_path.png" %>
   </div>
   <div class="my-6">
-    <p class="mb-2 text-lg">3. 光の時間での行動を登録</p>
+    <p class="mb-2 text-lg">3. 光の時間での行動（本来望んでいるけど中々できないこと）を登録</p>
     <p class="mb-2 text-md">
       ※ なりたい自分や光の時間の特徴について、見つかっていない場合は無理に埋めなくても大丈夫です。
     </p>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
-  <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-4 py-2 rounded-lg" %>
+  <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">
-    <div class="w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
+    <div class="w-80 md:w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
 
       <h2 class="text-center text-2xl font-bold mb-6">アカウント作成</h2>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
-  <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-4 py-2 rounded-lg" %>
+  <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">
-    <div class="w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
+    <div class="w-80 md:w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
 
       <h2 class="text-center text-2xl font-bold mb-6">ログイン</h2>
 


### PR DESCRIPTION
# 概要
スマホ画面に対応できるようにcssのclass属性の調整を行います。

以下の画面に対して、cssの幅調整を行っていることを確認しました。

- [x] ホーム画面
- [x] ログイン画面
- [x] アカウント作成画面
- [x] マイページ
- [x] 闇の時間の活動内容の新規登録画面
- [x] 闇の時間の活動内容の詳細画面
- [x] 闇の時間の活動内容の編集画面
- [x] 光の時間の活動内容の新規登録画面
- [x] 光の時間の活動内容の詳細画面
- [x] 光の時間の活動内容の編集画面
- [x] ポモドーロータイマー活動時間の画面
- [x] ポモドーロータイマー休憩時間の画面
- [x] モチベーションの画面
- [x] 光の時間の活動記録の新規登録画面
- [x] 光の時間の活動記録の一覧画面
- [x] 光の時間の活動記録の詳細画面
- [x] 光の時間の活動記録の編集画面

# 補足事項
- 画面の幅調整において、端の部分にコンテンツがひっついてしまうケースに対して、修正を行いました。
- 一部（光と闇の活動内容のフォーム、光の時間の活動記録）、ボタンのスタイルにおいて統一を行いました。
- 文章やボタンの文字の大きさ、パディング、余白は個人的に気になる部分のみ修正を行いました。全体での統一は行っていないです。
- 使い方画面において概要を追記しました。
- step1及びstep2において闇と光の時間での行動が何であるのかをイメージできるように補足説明を追記しました。