### PR TITLE
fix: 光の時間の活動内容の画面切り替えができるように修正

### DIFF
--- a/app/views/mypages/_light_time.html.erb
+++ b/app/views/mypages/_light_time.html.erb
@@ -1,7 +1,7 @@
 <% light_times = current_user.light_times.order(:created_at).pluck(:id) %>
 
 <% if light_time.present? %>
-  <div id="light-time-switch" data-controller="light-time-switch" data-light_times="<%= light_times.to_json %>" data-current-id="<%= @light_time.id %>" class="flex flex-col items-center gap-6 md:block">
+  <div id="light-time-switch" data-controller="light-time-switch" data-light_times="<%= light_times.to_json %>" data-current-id="<%= @light_time.id %>">
     <div class="flex flex-row md:flex-col items-center justify-center gap-6 text-zinc-800">
 
       <% if light_times.size > 1 %>
@@ -37,13 +37,6 @@
       <% end %>
 
     </div>
-
-    <!-- スマホ対応画面における新規登録ボタン -->
-    <% if both_times_present?(dark_time, light_time) %>
-      <div class="md:hidden">
-        <%= link_to "新規登録", new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
-      </div>
-    <% end %>
 
   </div>
 <% else %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -69,8 +69,17 @@
         <%= render "pomodoro_start" %>
       <% end %>
 
-      <!-- ☀ 光側カード -->
-      <%= render "light_time", light_time: @light_time, dark_time: @dark_time %>
+      <div class="flex flex-col items-center gap-6 md:block">
+        <!-- ☀ 光側カード -->
+        <%= render "light_time", light_time: @light_time %>
+
+        <!-- スマホ対応画面における新規登録ボタン -->
+        <% if both_times_present?(@dark_time, @light_time) %>
+          <div class="md:hidden">
+            <%= link_to "新規登録", new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+          </div>
+        <% end %>
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
# 概要
光の時間の活動内容の画面切り替えを行うと、エラーが発生することを本番環境で確認。原因は、app/views/mypages/_light_time.html.erb において、

```
<%= render "light_time", light_time: @light_time, dark_time: @dark_time %>
```
と記述したところにあった。マイページに遷移する際には問題ないが、光の時間の活動内容の画面切り替えのイベントが発生すると、stimulus及びturboによる非同期通信において、@dark_time を取得していないことにあった。

@dark_time は、スマホ画面の際に表示する新規登録ボタンを、光と闇の時間を登録している場合に表示する条件分岐に用いるため、パーシャルの引数として導入していた。

従って、非同期通信による画面切り替えイベントとは無関係のため、スマホ画面の際に表示する新規登録ボタンを表示する処理内容をパーシャルファイルの内容から、外側のファイルである app/views/mypages/show.html.erb へ移動することにした。
