### PR TITLE
add: 闇の時間の活動内容についてのテストコードの追加

### DIFF
--- a/app/controllers/dark_times_controller.rb
+++ b/app/controllers/dark_times_controller.rb
@@ -1,5 +1,7 @@
 class DarkTimesController < ApplicationController
   before_action :set_dark_time, only: %i[show edit update]
+  before_action :redirect_if_dark_time_exists, only: %i[new create]
+  before_action :redirect_if_dark_time_missing, only: %i[edit]
 
   def new
     @dark_time = current_user.build_dark_time
@@ -32,6 +34,20 @@ class DarkTimesController < ApplicationController
 
   def set_dark_time
     @dark_time = current_user.dark_time
+  end
+
+  # 既に DarkTime が存在する場合は edit にリダイレクト
+  def redirect_if_dark_time_exists
+    return unless current_user.dark_time.present?
+
+    redirect_to edit_dark_time_path, alert: t('defaults.flash_message.already_exists', item: DarkTime.model_name.human)
+  end
+
+  # DarkTime が存在しない場合は new にリダイレクト
+  def redirect_if_dark_time_missing
+    return if current_user.dark_time.present?
+
+    redirect_to new_dark_time_path, alert: t('defaults.flash_message.not_found', item: DarkTime.model_name.human)
   end
 
   def dark_time_params

--- a/app/models/dark_time.rb
+++ b/app/models/dark_time.rb
@@ -1,5 +1,6 @@
 class DarkTime < ApplicationRecord
   validates :behavior, presence: true
+  validates :user_id, uniqueness: true
 
   belongs_to :user
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -6,6 +6,8 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新できませんでした"
       deleted: "%{item}を削除しました"
+      already_exists: "%{item}は既に作成済みです"
+      not_found: "%{item}が見つかりません"
   activity_records:
     flash_message:
       require_timer_access: ポモドーロタイマーからアクセスしてください

--- a/spec/factories/dark_times.rb
+++ b/spec/factories/dark_times.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :dark_time do
+    behavior { "夜更かししてしまう" }
+    characteristic { "意志が弱い" }
+    unwanted_future { "健康を損なう" }
+    association :user
+  end
+end

--- a/spec/models/dark_time_spec.rb
+++ b/spec/models/dark_time_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe DarkTime, type: :model do
+  describe "validations" do
+    it "behaviorがあれば有効" do
+      dark_time = build(:dark_time)
+      expect(dark_time).to be_valid
+    end
+
+    it "behaviorがないと無効" do
+      dark_time = build(:dark_time, behavior: nil)
+      expect(dark_time).to be_invalid
+      expect(dark_time.errors[:behavior]).to be_present
+    end
+
+    it "userごとに1件のみ" do
+      user = create(:user)
+      create(:dark_time, user: user)
+
+      second = build(:dark_time, user: user)
+      expect(second).to be_invalid
+      expect(second.errors[:user_id]).to be_present
+    end
+  end
+
+  describe "associations" do
+    it "userに属している" do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq(:belongs_to)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe User, type: :model do
     it "nameがないと無効" do
       user = build(:user, name: nil)
       expect(user).to be_invalid
+      expect(user.errors[:name]).to be_present
     end
 
     it "nameが30文字以内なら有効" do
@@ -20,6 +21,7 @@ RSpec.describe User, type: :model do
     it "nameが31文字以上だと無効" do
       user = build(:user, name: "a" * 31)
       expect(user).to be_invalid
+      expect(user.errors[:name]).to be_present
     end
   end
 

--- a/spec/requests/dark_times_spec.rb
+++ b/spec/requests/dark_times_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+RSpec.describe "DarkTimes", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "POST /dark_time" do
+    let(:success_message) do
+      I18n.t('defaults.flash_message.created', item: DarkTime.model_name.human)
+    end
+
+    let(:failure_message) do
+      I18n.t('defaults.flash_message.not_created', item: DarkTime.model_name.human)
+    end
+
+    context "正常系" do
+      it "DarkTimeを作成できる" do
+        expect {
+          post dark_time_path, params: {
+            dark_time: {
+              behavior: "スマホを触りすぎる",
+              characteristic: "集中力がない",
+              unwanted_future: "生産性が下がる"
+            }
+          }
+        }.to change(DarkTime, :count).by(1)
+
+        expect(response).to redirect_to(mypage_path)
+        expect(flash[:notice]).to eq(success_message)
+      end
+    end
+
+    context "異常系" do
+      it "behaviorがないと作成できない" do
+        expect {
+          post dark_time_path, params: {
+            dark_time: {
+              behavior: ""
+            }
+          }
+        }.not_to change(DarkTime, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(flash[:alert]).to eq(failure_message)
+      end
+    end
+
+    context "既に作成済みの場合" do
+      let!(:existing_dark_time) { create(:dark_time, user: user) }
+
+      it "2件目は作成できず、編集画面にリダイレクトされる" do
+        expect {
+          post dark_time_path, params: {
+            dark_time: { behavior: "別の行動" }
+          }
+        }.not_to change(DarkTime, :count)
+
+        expect(response).to redirect_to(edit_dark_time_path)
+        expect(flash[:alert]).to eq(
+          I18n.t('defaults.flash_message.already_exists', item: DarkTime.model_name.human)
+        )
+      end
+    end
+  end
+
+  describe "PATCH /dark_time" do
+    let!(:dark_time) { create(:dark_time, user: user) }
+
+    let(:success_message) do
+      I18n.t('defaults.flash_message.updated', item: DarkTime.model_name.human)
+    end
+
+    let(:failure_message) do
+      I18n.t('defaults.flash_message.not_updated', item: DarkTime.model_name.human)
+    end
+
+    it "更新できる" do
+      patch dark_time_path, params: {
+        dark_time: { behavior: "改善後" }
+      }
+
+      expect(response).to redirect_to(dark_time_path)
+      expect(flash[:notice]).to eq(success_message)
+      expect(dark_time.reload.behavior).to eq("改善後")
+    end
+
+    it "バリデーションエラー時は更新されない" do
+      patch dark_time_path, params: {
+        dark_time: { behavior: "" }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(flash[:alert]).to eq(failure_message)
+      expect(dark_time.reload.behavior).not_to eq("")
+    end
+  end
+
+  describe "GET /dark_time" do
+    let!(:dark_time) { create(:dark_time, user: user) }
+
+    it "詳細画面が表示される" do
+      get dark_time_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /dark_time/new" do
+    context "DarkTimeが未作成の場合" do
+      it "新規作成画面が表示される" do
+        get new_dark_time_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "既にDarkTimeが作成済みの場合" do
+      let!(:dark_time) { create(:dark_time, user: user) }
+
+      it "編集画面にリダイレクトされる" do
+        get new_dark_time_path
+        expect(response).to redirect_to(edit_dark_time_path)
+        expect(flash[:alert]).to eq(
+          I18n.t('defaults.flash_message.already_exists', item: DarkTime.model_name.human)
+        )
+      end
+    end
+  end
+
+  describe "GET /dark_time/edit" do
+    context "DarkTimeが存在する場合" do
+      let!(:dark_time) { create(:dark_time, user: user) }
+
+      it "編集画面が表示される" do
+        get edit_dark_time_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "DarkTimeが存在しない場合" do
+      it "新規作成画面にリダイレクトされる" do
+        get edit_dark_time_path
+        expect(response).to redirect_to(new_dark_time_path)
+        expect(flash[:alert]).to eq(
+          I18n.t('defaults.flash_message.not_found', item: DarkTime.model_name.human)
+        )
+      end
+    end
+  end
+end

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -1,7 +1,40 @@
 require 'rails_helper'
 
-RSpec.describe "Authentication", type: :system do
+RSpec.describe "Authentications", type: :system do
   let!(:user) { create(:user) }
+
+  it "新規登録できる" do
+    visit new_user_registration_path
+
+    fill_in "名前", with: "山田太郎"
+    fill_in "メールアドレス", with: "new@example.com"
+    fill_in "パスワード", with: "password123"
+    fill_in "パスワード確認", with: "password123"
+    click_button "アカウント作成"
+
+    expect(page).to have_current_path(root_path)
+    expect(page).to have_content(
+      I18n.t("devise.registrations.signed_up")
+    )
+  end
+
+  it "新規登録に失敗するとエラーメッセージが表示される" do
+    visit new_user_registration_path
+
+    fill_in "名前", with: "山田太郎"
+    fill_in "メールアドレス", with: ""
+    fill_in "パスワード", with: "password123"
+    fill_in "パスワード確認", with: "password123"
+    click_button "アカウント作成"
+
+    expect(page).to have_current_path(new_user_registration_path)
+
+    # エラーメッセージ
+    expect(page).to have_content("メールアドレスを入力してください")
+    # 入力した値が保持されているか
+    expect(page).to have_field("名前", with: "山田太郎")
+    expect(page).to have_field("メールアドレス", with: "")
+  end
 
   it "ログインできる" do
     visit new_user_session_path
@@ -13,21 +46,6 @@ RSpec.describe "Authentication", type: :system do
     expect(page).to have_current_path(root_path)
     expect(page).to have_content(
       I18n.t("devise.sessions.signed_in")
-    )
-  end
-
-  it "新規登録できる" do
-    visit new_user_registration_path
-
-    fill_in "名前", with: "new@example.com"
-    fill_in "メールアドレス", with: "new@example.com"
-    fill_in "パスワード", with: "password123"
-    fill_in "パスワード確認", with: "password123"
-    click_button "アカウント作成"
-
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content(
-      I18n.t("devise.registrations.signed_up")
     )
   end
 

--- a/spec/system/dark_times_spec.rb
+++ b/spec/system/dark_times_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe "DarkTimes", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "DarkTime作成" do
+    context "正常系" do
+      it "作成後にマイページで表示される" do
+        # 新規作成ページにアクセス
+        visit new_dark_time_path
+
+        # フォームに入力
+        fill_in "闇の時間での行動", with: "スマホを触りすぎる"
+        fill_in "避けたい未来", with: "生産性が下がる"
+        fill_in "闇の時間の特徴", with: "集中力がない"
+
+        # 作成ボタンをクリック
+        click_button "登録する"
+
+        # マイページにリダイレクトされる
+        expect(page).to have_current_path(mypage_path)
+
+        # 作成したDarkTimeが表示される
+        expect(page).to have_content("スマホを触りすぎる")
+        expect(page).to have_content("生産性が下がる")
+
+        # フラッシュメッセージが表示される
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.created', item: DarkTime.model_name.human)
+        )
+      end
+    end
+
+    context "異常系" do
+      it "behaviorが未入力の場合、作成できない" do
+        visit new_dark_time_path
+
+        # behaviorを未入力のまま送信
+        fill_in "避けたい未来", with: "生産性が下がる"
+        click_button "登録する"
+
+        # エラーメッセージが表示される
+        expect(page).to have_content("闇の時間での行動を入力してください")
+
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.not_created', item: DarkTime.model_name.human)
+        )
+
+        # 作成画面に留まる
+        expect(page).to have_current_path(new_dark_time_path)
+      end
+    end
+  end
+
+  describe "DarkTime編集" do
+    let!(:dark_time) { create(:dark_time, user: user, behavior: "元の行動") }
+
+    context "正常系" do
+      it "編集後にマイページで表示される" do
+        visit edit_dark_time_path
+
+        fill_in "闇の時間での行動", with: "改善後の行動"
+        click_button "更新する"
+
+        expect(page).to have_current_path(dark_time_path)
+        expect(page).to have_content("改善後の行動")
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.updated', item: DarkTime.model_name.human)
+        )
+      end
+    end
+
+    context "異常系" do
+      it "behaviorを空にすると更新できない" do
+        visit edit_dark_time_path
+
+        fill_in "闇の時間での行動", with: ""
+        click_button "更新する"
+
+        expect(page).to have_content("闇の時間での行動を入力してください")
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.not_updated', item: DarkTime.model_name.human)
+        )
+        expect(page).to have_current_path(edit_dark_time_path)
+      end
+    end
+  end
+
+  describe "DarkTime詳細表示" do
+    let!(:dark_time) { create(:dark_time, user: user, behavior: "スマホを触りすぎる") }
+
+    it "詳細ページで内容が表示される" do
+      visit dark_time_path
+
+      expect(page).to have_content("スマホを触りすぎる")
+      expect(page).to have_content(dark_time.unwanted_future)
+      expect(page).to have_content(dark_time.characteristic)
+    end
+  end
+
+  describe "DarkTimeが未作成の場合" do
+    it "newページにアクセスすると新規作成画面が表示される" do
+      visit new_dark_time_path
+
+      expect(page).to have_content("闇の時間での活動内容登録")
+      expect(page).to have_field("闇の時間での行動")
+      expect(page).to have_button("登録する")
+    end
+  end
+
+  describe "DarkTimeが作成済みの場合" do
+    let!(:dark_time) { create(:dark_time, user: user) }
+
+    it "newページにアクセスすると編集画面にリダイレクトされる" do
+      visit new_dark_time_path
+
+      expect(page).to have_current_path(edit_dark_time_path)
+      expect(page).to have_content(
+        I18n.t('defaults.flash_message.already_exists', item: DarkTime.model_name.human)
+      )
+    end
+  end
+end


### PR DESCRIPTION
# 概要
闇の時間の活動内容についてのテストコードの追加を行います。

- [x] カラムのモデルスペックの作成
- [x] 闇の時間の活動内容の新規登録機能に関するテストコードの作成
- [x] 闇の時間の活動内容の詳細画面に関するテストコードの作成
- [x] 闇の時間の活動内容の編集機能に関するテストコードの作成

### 補足事項
- 認証機能において、入力内容が保持されていることを確認するため、システムスペックにおいて、新規登録できないケースを追加しました

テストコード作成時にメイン機能で修正が必要であることが判明したため、行いました：
- user_idにユニーク制約を追加
- 新規登録前に編集画面にアクセスすると、新規登録画面へとリダイレクトされるように修正しました
- 新規登録後に新規登録画面にアクセスすると、編集画面へとリダイレクトされるように修正しました
- 2つ以上登録できないように実装を行いました