### PR TITLE
add: 活動時間の計測&活動記録新規登録、詳細、編集、削除機能、検索機能、ページネーションのテストコードの作成

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -66,7 +66,8 @@ class ActivityRecordsController < ApplicationController
   end
 
   def set_light_and_dark_times
-    @light_time = current_user.light_times.find_by(is_current: true)
+    light_time_id = params.dig(:activity_record_form, :light_time_id)
+    @light_time = current_user.light_times.find_by(id: light_time_id)
     @dark_time = current_user.dark_time
   end
 
@@ -74,7 +75,7 @@ class ActivityRecordsController < ApplicationController
     params.require(:activity_record_form).permit(
     :started_at, :ended_at, :task, :total_duration,
     :idle_duration, :satisfaction, :progress,
-    :quality, :focus, :fatigue, :comment,
+    :quality, :focus, :fatigue, :light_time_id, :comment,
     :light_time_characteristic, :dark_time_characteristic
     )
   end

--- a/app/forms/activity_record_form.rb
+++ b/app/forms/activity_record_form.rb
@@ -18,6 +18,7 @@ class ActivityRecordForm
   attribute :quality, :integer
   attribute :focus, :integer
   attribute :fatigue, :integer
+  attribute :light_time_id, :integer
 
   # ===== バリデーション =====
   validates :idle_duration, numericality: { greater_than_or_equal_to: 0 }
@@ -30,7 +31,8 @@ class ActivityRecordForm
     return false unless valid?
 
     ActiveRecord::Base.transaction do
-      light_time = user.light_times.find_by(is_current: true)
+      # find_by(is_current: true) をやめて、IDで直接取得
+      light_time = user.light_times.find_by(id: light_time_id)
 
       # ActivityRecord 作成
       user.activity_records.create!(
@@ -49,7 +51,7 @@ class ActivityRecordForm
       )
 
       # LightTime 更新
-      user.light_times.find_by(is_current: true)&.update!(
+      user.light_times.find_by(id: light_time_id).update!(
         characteristic: light_time_characteristic
       )
 

--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
   static values = {
     workDuration: { type: Number, default: 1500 },
     breakDuration: { type: Number, default: 300 },
-    task: {type: String, default: null}
+    task: {type: String, default: null},
+    lightTimeId: { type: Number, default: null }
   }
 
   connect() {
@@ -300,7 +301,8 @@ export default class extends Controller {
       'activity_record_form[task]': this.task,
       'activity_record_form[started_at]': this.firstStartedAt.toISOString(),
       'activity_record_form[ended_at]': lastEndedAt.toISOString(),
-      'activity_record_form[total_duration]': durationInMinutes
+      'activity_record_form[total_duration]': durationInMinutes,
+      'activity_record_form[light_time_id]': this.lightTimeIdValue
     })
     return params
   }

--- a/app/views/activity_records/new.html.erb
+++ b/app/views/activity_records/new.html.erb
@@ -18,6 +18,7 @@
       <%= f.hidden_field :ended_at %>
       <%= f.hidden_field :task %>
       <%= f.hidden_field :total_duration %>
+      <%= f.hidden_field :light_time_id %>
 
       <!-- 光の時間の活動内容 -->
       <div class="text-center mb-6">

--- a/app/views/activity_records/pomodoro_timer.html.erb
+++ b/app/views/activity_records/pomodoro_timer.html.erb
@@ -1,4 +1,8 @@
-<div data-controller="pomodoro" data-pomodoro-work-duration-value="1500" data-pomodoro-break-duration-value="300" data-pomodoro-task-value="<%= @activity_record.task %>">
+<div data-controller="pomodoro"
+     data-pomodoro-work-duration-value="1500"
+     data-pomodoro-break-duration-value="300"
+     data-pomodoro-task-value="<%= @activity_record.task %>"
+     data-pomodoro-light-time-id-value="<%= @light_time&.id %>">
 
   <%= render "activity_records/pomodoro/work_screen" %>
 

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,20 +6,22 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<nav class="flex justify-center my-6">
-  <ul class="flex items-center gap-2">
-    <%= paginator.render do %>
-      <%= prev_page_tag unless current_page.first? %>
+<% if total_pages > 1 %>
+  <nav class="flex justify-center my-6" data-test="pagination">
+    <ul class="flex items-center gap-2">
+      <%= paginator.render do %>
+        <%= prev_page_tag unless current_page.first? %>
 
-      <% each_page do |page| %>
-        <% if page.display_tag? %>
-          <%= page_tag page %>
-        <% elsif !page.was_truncated? %>
-          <%= gap_tag %>
+        <% each_page do |page| %>
+          <% if page.display_tag? %>
+            <%= page_tag page %>
+          <% elsif !page.was_truncated? %>
+            <%= gap_tag %>
+          <% end %>
         <% end %>
-      <% end %>
 
-      <%= next_page_tag unless current_page.last? %>
-    <% end %>
-  </ul>
-</nav>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </ul>
+  </nav>
+<% end %>

--- a/spec/factories/activity_records.rb
+++ b/spec/factories/activity_records.rb
@@ -1,0 +1,56 @@
+FactoryBot.define do
+  factory :activity_record do
+    association :user
+    # light_time の is_current は false がデフォルトのため :current トレイトで明示
+    association :light_time, factory: %i[light_time current]
+
+    started_at     { 1.hour.ago }
+    ended_at       { Time.current }
+    total_duration { 60 }
+    idle_duration  { 0 }
+    satisfaction   { 3 }
+    progress       { 3 }
+    quality        { 3 }
+    focus          { 3 }
+    fatigue        { 3 }
+    task           { '学習する' }
+    comment        { '集中できた' }
+
+    # 評価が最高のレコード
+    trait :high_rating do
+      satisfaction { 5 }
+      progress     { 5 }
+      quality      { 5 }
+      focus        { 5 }
+      fatigue      { 1 }
+    end
+
+    # 評価が最低のレコード
+    trait :low_rating do
+      satisfaction { 1 }
+      progress     { 1 }
+      quality      { 1 }
+      focus        { 1 }
+      fatigue      { 5 }
+    end
+
+    # 浄化タイマーが付与される長時間セッション（90分 → 30分付与）
+    trait :long_session do
+      total_duration { 90 }
+      idle_duration  { 0 }
+    end
+
+    # 浄化タイマーが付与されない短時間セッション（20分）
+    trait :short_session do
+      total_duration { 20 }
+      idle_duration  { 0 }
+    end
+
+    # 昨日の記録
+    trait :yesterday do
+      started_at  { 25.hours.ago }
+      ended_at    { 24.hours.ago }
+      created_at  { 1.day.ago }
+    end
+  end
+end

--- a/spec/factories/purification_times.rb
+++ b/spec/factories/purification_times.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :purification_time do
+    remaining_time { 0 }
+
+    association :user
+  end
+end

--- a/spec/forms/activity_record_form_spec.rb
+++ b/spec/forms/activity_record_form_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe ActivityRecordForm, type: :model do
+  let(:user)        { create(:user) }
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  let(:valid_attributes) do
+    {
+      started_at:                1.hour.ago,
+      ended_at:                  Time.current,
+      total_duration:            60,
+      idle_duration:             5,
+      satisfaction:              3,
+      progress:                  3,
+      quality:                   3,
+      focus:                     3,
+      fatigue:                   3,
+      task:                      'RSpec を書く',
+      comment:                   'テストコメント',
+      light_time_id:             light_time.id,
+      light_time_characteristic: '集中しやすい朝の時間',
+      dark_time_characteristic:  'スマホを見てしまう時間'
+    }
+  end
+
+  subject(:form) { described_class.new(valid_attributes) }
+
+  # =========================================================
+  # バリデーション
+  # =========================================================
+  describe 'バリデーション' do
+    context '正常な値のとき' do
+      it '有効であること' do
+        expect(form).to be_valid
+      end
+    end
+
+    describe 'idle_duration' do
+      it '負の値は無効' do
+        form.idle_duration = -1
+        expect(form).to be_invalid
+        expect(form.errors[:idle_duration]).to be_present
+      end
+
+      it 'total_duration を超えると無効' do
+        form.idle_duration = form.total_duration + 1
+        expect(form).to be_invalid
+        expect(form.errors[:idle_duration]).to include('は合計時間以下にしてください')
+      end
+
+      it 'total_duration と同値は有効' do
+        form.idle_duration = form.total_duration
+        expect(form).to be_valid
+      end
+    end
+
+    describe '5段階評価カラム' do
+      %i[satisfaction progress quality focus fatigue].each do |attr|
+        context attr.to_s do
+          it '0 は無効' do
+            form.send(:"#{attr}=", 0)
+            expect(form).to be_invalid
+            expect(form.errors[attr]).to be_present
+          end
+
+          it '6 は無効' do
+            form.send(:"#{attr}=", 6)
+            expect(form).to be_invalid
+            expect(form.errors[attr]).to be_present
+          end
+
+          it '3 は有効' do
+            form.send(:"#{attr}=", 3)
+            expect(form).to be_valid
+          end
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # #save
+  # =========================================================
+  describe '#save' do
+    context '正常な値のとき' do
+      it 'true を返すこと' do
+        expect(form.save(user)).to be true
+      end
+
+      it 'ActivityRecord が 1 件作成されること' do
+        expect { form.save(user) }.to change(ActivityRecord, :count).by(1)
+      end
+
+      it '作成された ActivityRecord の各値が正しいこと' do
+        form.save(user)
+        activity_record = ActivityRecord.last
+        aggregate_failures do
+          expect(activity_record.task).to           eq 'RSpec を書く'
+          expect(activity_record.comment).to        eq 'テストコメント'
+          expect(activity_record.total_duration).to eq 60
+          expect(activity_record.idle_duration).to  eq 5
+          expect(activity_record.satisfaction).to   eq 3
+          expect(activity_record.light_time).to     eq light_time
+        end
+      end
+
+      it 'LightTime の characteristic が更新されること' do
+        form.save(user)
+        expect(light_time.reload.characteristic).to eq '集中しやすい朝の時間'
+      end
+
+      it 'DarkTime の characteristic が更新されること' do
+        form.save(user)
+        expect(dark_time.reload.characteristic).to eq 'スマホを見てしまう時間'
+      end
+
+      context 'light_time_characteristic が空文字のとき' do
+        before { form.light_time_characteristic = '' }
+
+        it 'LightTime の characteristic が空文字に更新されること' do
+          form.save(user)
+          expect(light_time.reload.characteristic).to eq ''
+        end
+      end
+    end
+
+    context 'バリデーションエラーのとき（satisfaction = 0）' do
+      before { form.satisfaction = 0 }
+
+      it 'false を返すこと' do
+        expect(form.save(user)).to be false
+      end
+
+      it 'ActivityRecord が作成されないこと' do
+        expect { form.save(user) }.not_to change(ActivityRecord, :count)
+      end
+
+      it 'LightTime が更新されないこと' do
+        original = light_time.characteristic
+        form.save(user)
+        expect(light_time.reload.characteristic).to eq original
+      end
+    end
+
+    context 'light_time_id が nil のとき' do
+      before { form.light_time_id = nil }
+
+      it 'save が false を返すこと' do
+        expect(form.save(user)).to be false
+      end
+
+      it 'ActivityRecord が作成されないこと' do
+        expect { form.save(user) }.not_to change(ActivityRecord, :count)
+      end
+    end
+  end
+end

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+
+RSpec.describe ActivityRecord, type: :model do
+  let(:user)       { create(:user) }
+  # is_current: false がデフォルトのため :current トレイトを明示
+  let(:light_time) { create(:light_time, :current, user: user) }
+
+  # =========================================================
+  # バリデーション
+  # =========================================================
+  describe 'バリデーション' do
+    context '正常な値のとき' do
+      subject { build(:activity_record, user: user, light_time: light_time) }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe 'idle_duration' do
+      subject(:record) { build(:activity_record, user: user, light_time: light_time) }
+
+      it '0 は有効' do
+        record.idle_duration = 0
+        expect(record).to be_valid
+      end
+
+      it '負の値は無効' do
+        record.idle_duration = -1
+        expect(record).to be_invalid
+        expect(record.errors[:idle_duration]).to be_present
+      end
+
+      it 'total_duration を超えると無効' do
+        record.idle_duration = record.total_duration + 1
+        expect(record).to be_invalid
+        expect(record.errors[:idle_duration]).to include('は合計時間以下にしてください')
+      end
+
+      it 'total_duration と同値は有効' do
+        record.idle_duration = record.total_duration
+        expect(record).to be_valid
+      end
+    end
+
+    describe '5段階評価カラム' do
+      subject(:record) { build(:activity_record, user: user, light_time: light_time) }
+
+      %i[satisfaction progress quality focus fatigue].each do |attr|
+        context attr.to_s do
+          (1..5).each do |v|
+            it "#{v} は有効" do
+              record.send(:"#{attr}=", v)
+              expect(record).to be_valid
+            end
+          end
+
+          [0, 6].each do |v|
+            it "#{v} は無効" do
+              record.send(:"#{attr}=", v)
+              expect(record).to be_invalid
+              expect(record.errors[attr]).to be_present
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # .calculate_purification_time
+  # =========================================================
+  describe '.calculate_purification_time' do
+    subject { described_class.calculate_purification_time(total_duration) }
+
+    context 'nil のとき' do
+      let(:total_duration) { nil }
+      it { is_expected.to eq 0 }
+    end
+
+    context '0 分のとき' do
+      let(:total_duration) { 0 }
+      it { is_expected.to eq 0 }
+    end
+
+    context '29 分（30 未満）のとき' do
+      let(:total_duration) { 29 }
+      it { is_expected.to eq 0 }
+    end
+
+    context '30 分のとき' do
+      let(:total_duration) { 30 }
+      it { is_expected.to eq 10 }
+    end
+
+    context '59 分のとき' do
+      let(:total_duration) { 59 }
+      it { is_expected.to eq 10 }
+    end
+
+    context '60 分のとき' do
+      let(:total_duration) { 60 }
+      it { is_expected.to eq 20 }
+    end
+
+    context '120 分のとき' do
+      let(:total_duration) { 120 }
+      it { is_expected.to eq 40 }
+    end
+  end
+
+  # =========================================================
+  # .total_light_time_today
+  # =========================================================
+  describe '.total_light_time_today' do
+    subject { described_class.total_light_time_today(user) }
+
+    context '今日の記録がないとき' do
+      it { is_expected.to eq 0 }
+    end
+
+    context '今日の記録が複数あるとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time, total_duration: 30)
+        create(:activity_record, user: user, light_time: light_time, total_duration: 45)
+      end
+
+      it '合計値を返すこと' do
+        is_expected.to eq 75
+      end
+    end
+
+    context '昨日の記録しかないとき' do
+      before { create(:activity_record, :yesterday, user: user, light_time: light_time) }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context '別ユーザーの記録は集計に含まないこと' do
+      let(:other_user)  { create(:user) }
+      let(:other_light) { create(:light_time, :current, user: other_user) }
+
+      before do
+        create(:activity_record, user: other_user, light_time: other_light, total_duration: 999)
+      end
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  # =========================================================
+  # before_save: calculate_desired_self_percentage
+  # =========================================================
+  describe 'desired_self_percentage の計算' do
+    it '正しい割合が保存されること' do
+      record = create(:activity_record, user: user, light_time: light_time,
+                      total_duration: 100, idle_duration: 20)
+      # (100 - 20) / 100.0 = 0.8
+      expect(record.desired_self_percentage).to be_within(0.001).of(0.8)
+    end
+
+    it 'idle_duration が 0 のとき 1.0 になること' do
+      record = create(:activity_record, user: user, light_time: light_time,
+                      total_duration: 60, idle_duration: 0)
+      expect(record.desired_self_percentage).to be_within(0.001).of(1.0)
+    end
+
+    it 'total_duration が 0 のときは nil のままであること' do
+      record = build(:activity_record, user: user, light_time: light_time,
+                     total_duration: 0, idle_duration: 0)
+      record.save(validate: false)
+      expect(record.desired_self_percentage).to be_nil
+    end
+  end
+
+  # =========================================================
+  # after_create: grant_purification_time
+  # =========================================================
+  describe 'grant_purification_time コールバック' do
+    let!(:purification_time) { create(:purification_time, user: user, remaining_time: 0) }
+
+    context ':long_session（90 分）のとき' do
+      it 'remaining_time に 1800 秒（30 分）加算されること' do
+        # (90 / 30).floor * 10 = 30 分付与 → 30 * 60 = 1800 秒
+        create(:activity_record, :long_session, user: user, light_time: light_time)
+        expect(purification_time.reload.remaining_time).to eq 1800
+      end
+    end
+
+    context ':short_session（20 分）のとき' do
+      it 'remaining_time が変化しないこと' do
+        create(:activity_record, :short_session, user: user, light_time: light_time)
+        expect(purification_time.reload.remaining_time).to eq 0
+      end
+    end
+  end
+end

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -6,6 +6,21 @@ RSpec.describe ActivityRecord, type: :model do
   let(:light_time) { create(:light_time, :current, user: user) }
 
   # =========================================================
+  # アソシエーション
+  # =========================================================
+  describe 'アソシエーション' do
+    it 'User に属していること' do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq :belongs_to
+    end
+
+    it 'LightTime に属していること' do
+      association = described_class.reflect_on_association(:light_time)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+
+  # =========================================================
   # バリデーション
   # =========================================================
   describe 'バリデーション' do
@@ -190,6 +205,16 @@ RSpec.describe ActivityRecord, type: :model do
         create(:activity_record, :short_session, user: user, light_time: light_time)
         expect(purification_time.reload.remaining_time).to eq 0
       end
+    end
+  end
+
+  describe 'ransack の検索可能カラム' do
+    it '検索可能なカラムが comment のみであること' do
+      expect(described_class.ransackable_attributes).to eq ['comment']
+    end
+
+    it '検索可能な関連付けが light_time のみであること' do
+      expect(described_class.ransackable_associations).to eq ['light_time']
     end
   end
 end

--- a/spec/models/dark_time_spec.rb
+++ b/spec/models/dark_time_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe DarkTime, type: :model do
   end
 
   describe "アソシエーション" do
-    it "Userに属していること" do
+    it "User に属していること" do
       association = described_class.reflect_on_association(:user)
-      expect(association.macro).to eq(:belongs_to)
+      expect(association.macro).to eq :belongs_to
     end
   end
 end

--- a/spec/models/light_time_spec.rb
+++ b/spec/models/light_time_spec.rb
@@ -2,9 +2,17 @@ require 'rails_helper'
 
 RSpec.describe LightTime, type: :model do
   describe "アソシエーション" do
-    it "Userに属していること" do
+    it "User に属していること" do
       association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq :belongs_to
+    end
+
+    it 'activity_records を dependent: :destroy で複数持つこと' do
+      association = described_class.reflect_on_association(:activity_records)
+      aggregate_failures do
+        expect(association.macro).to eq :has_many
+        expect(association.options[:dependent]).to eq :destroy
+      end
     end
   end
 
@@ -87,6 +95,12 @@ RSpec.describe LightTime, type: :model do
         expect(next_light_time.reload.is_current).to be false
         expect(third_light_time.reload.is_current).to be false
       end
+    end
+  end
+
+  describe '.ransackable_attributes' do
+    it 'action カラムのみ検索可能' do
+      expect(described_class.ransackable_attributes).to eq ["action"]
     end
   end
 end

--- a/spec/models/purification_time_spec.rb
+++ b/spec/models/purification_time_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe PurificationTime, type: :model do
+  describe 'アソシエーション' do
+    it 'User に属していること' do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+
+  # =========================================================
+  # アソシエーション
+  # =========================================================
+  describe 'アソシエーション' do
+    it 'dark_time を dependent: :destroy で1つ持つこと' do
+      association = described_class.reflect_on_association(:dark_time)
+      aggregate_failures do
+        expect(association.macro).to eq :has_one
+        expect(association.options[:dependent]).to eq :destroy
+      end
+    end
+
+    it 'light_times を dependent: :destroy で複数持つこと' do
+      association = described_class.reflect_on_association(:light_times)
+      aggregate_failures do
+        expect(association.macro).to eq :has_many
+        expect(association.options[:dependent]).to eq :destroy
+      end
+    end
+
+    it 'activity_records を dependent: :destroy で複数持つこと' do
+      association = described_class.reflect_on_association(:activity_records)
+      aggregate_failures do
+        expect(association.macro).to eq :has_many
+        expect(association.options[:dependent]).to eq :destroy
+      end
+    end
+
+    it 'purification_time を dependent: :destroy で1つ持つこと' do
+      association = described_class.reflect_on_association(:purification_time)
+      aggregate_failures do
+        expect(association.macro).to eq :has_one
+        expect(association.options[:dependent]).to eq :destroy
+      end
+    end
+  end
+
   describe "nameのバリデーション" do
     it "nameがあれば有効" do
       user = build(:user, name: "テスト")

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -1,0 +1,333 @@
+require 'rails_helper'
+
+RSpec.describe 'ActivityRecords', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let(:other_light_time) { create(:light_time, :current, user: other_user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before { sign_in user }
+
+  # =========================================================
+  # GET /activity_records (index)
+  # =========================================================
+  describe 'GET /activity_records' do
+    it '200 を返すこと' do
+      get activity_records_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    context '未ログインのとき' do
+      before { sign_out user }
+
+      it 'ログインページへリダイレクトすること' do
+        get activity_records_path
+        expect(response).to redirect_to(new_user_session_path)
+
+        follow_redirect!
+        expect(response.body).to include(
+          I18n.t("devise.failure.unauthenticated")
+        )
+      end
+    end
+
+    context '検索パラメータがあるとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time, comment: 'マッチするコメント')
+        create(:activity_record, user: user, light_time: light_time, comment: 'ヒットしない')
+      end
+
+      it '200 を返すこと' do
+        get activity_records_path, params: { q: { comment_or_light_time_action_cont: 'マッチ' } }
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  # =========================================================
+  # GET /activity_records/pomodoro_timer
+  # =========================================================
+  describe 'GET /activity_records/pomodoro_timer' do
+    it '200 を返すこと' do
+      get pomodoro_timer_activity_records_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # =========================================================
+  # GET /activity_records/new
+  # =========================================================
+  describe 'GET /activity_records/new' do
+    let(:form_params) do
+      {
+        activity_record_form: {
+          started_at:     1.hour.ago.iso8601,
+          ended_at:       Time.current.iso8601,
+          total_duration: 60,
+          task:           'タスク',
+          light_time_id:   light_time.id
+        }
+      }
+    end
+
+    context 'activity_record_form パラメータがあるとき' do
+      it '200 を返すこと' do
+        get new_activity_record_path, params: form_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'activity_record_form パラメータがないとき' do
+      it 'ポモドーロタイマーページへリダイレクトすること' do
+        get new_activity_record_path
+        expect(response).to redirect_to(pomodoro_timer_activity_records_path)
+        expect(flash[:alert]).to eq(
+          I18n.t('activity_records.flash_message.require_timer_access')
+        )
+      end
+    end
+  end
+
+  # =========================================================
+  # POST /activity_records (create)
+  # =========================================================
+  describe 'POST /activity_records' do
+    let(:valid_params) do
+      {
+        activity_record_form: {
+          started_at:                1.hour.ago.iso8601,
+          ended_at:                  Time.current.iso8601,
+          total_duration:            60,
+          idle_duration:             5,
+          satisfaction:              3,
+          progress:                  3,
+          quality:                   3,
+          focus:                     3,
+          fatigue:                   3,
+          task:                      'テストタスク',
+          light_time_id:             light_time.id,
+          comment:                   'テストコメント',
+          light_time_characteristic: '',
+          dark_time_characteristic:  ''
+        }
+      }
+    end
+
+    let(:success_message) do
+      I18n.t('defaults.flash_message.created', item: ActivityRecordForm.model_name.human)
+    end
+
+    let(:failure_message) do
+      I18n.t('defaults.flash_message.not_created', item: ActivityRecordForm.model_name.human)
+    end
+
+    context '正常なパラメータのとき' do
+      it 'ActivityRecord が 1 件増えること' do
+        expect { post activity_records_path, params: valid_params }
+          .to change(ActivityRecord, :count).by(1)
+      end
+
+      it '一覧ページへリダイレクトし、成功メッセージがセットされること' do
+        post activity_records_path, params: valid_params
+        aggregate_failures do
+          expect(response).to redirect_to(activity_records_path)
+          expect(flash[:notice]).to eq(success_message)
+        end
+      end
+
+      context 'total_duration >= 30 のとき' do
+        it 'flash[:purification_time] に付与メッセージがセットされること' do
+          post activity_records_path, params: valid_params
+          expect(flash[:purification_time]).to eq '浄化タイマーを20分獲得！'
+        end
+      end
+
+      context 'total_duration < 30 のとき' do
+        before { valid_params[:activity_record_form][:total_duration] = 10 }
+
+        it 'flash[:purification_time] がセットされないこと' do
+          post activity_records_path, params: valid_params
+          expect(flash[:purification_time]).to be_nil
+        end
+      end
+    end
+
+    context '不正なパラメータのとき（satisfaction が範囲外）' do
+      before { valid_params[:activity_record_form][:satisfaction] = 0 }
+
+      it 'ActivityRecord が増えないこと' do
+        expect { post activity_records_path, params: valid_params }
+          .not_to change(ActivityRecord, :count)
+      end
+
+      it '422 を返し、エラーメッセージがセットされること' do
+        post activity_records_path, params: valid_params
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # GET /activity_records/:id (show)
+  # =========================================================
+  describe 'GET /activity_records/:id' do
+    let(:activity_record) { create(:activity_record, user: user, light_time: light_time) }
+
+    it '200 を返すこと' do
+      get activity_record_path(activity_record)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '他ユーザーのレコードにアクセスすると 404 を返すこと' do
+      other_activity_record = create(:activity_record, user: other_user, light_time: other_light_time)
+
+      get activity_record_path(other_activity_record)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # =========================================================
+  # GET /activity_records/:id/edit
+  # =========================================================
+  describe 'GET /activity_records/:id/edit' do
+    let(:activity_record) { create(:activity_record, user: user, light_time: light_time) }
+
+    it '200 を返すこと' do
+      get edit_activity_record_path(activity_record)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '他ユーザーのレコードにアクセスすると 404 を返すこと' do
+      other_activity_record = create(:activity_record, user: other_user, light_time: other_light_time)
+
+      get edit_activity_record_path(other_activity_record)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # =========================================================
+  # PATCH /activity_records/:id (update)
+  # =========================================================
+  describe 'PATCH /activity_records/:id' do
+    let(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, comment: '元のコメント')
+    end
+
+    let(:success_message) do
+      I18n.t('defaults.flash_message.updated', item: ActivityRecord.model_name.human)
+    end
+
+    let(:failure_message) do
+      I18n.t('defaults.flash_message.not_updated', item: ActivityRecord.model_name.human)
+    end
+
+    context '正常なパラメータのとき' do
+      let(:update_params) do
+        {
+          activity_record: {
+            idle_duration: 10,
+            satisfaction:  5,
+            progress:      4,
+            quality:       4,
+            focus:         5,
+            fatigue:       2,
+            comment:       '更新後のコメント'
+          }
+        }
+      end
+
+      it '詳細ページへリダイレクトし、成功メッセージがセットされること' do
+        patch activity_record_path(activity_record), params: update_params
+        aggregate_failures do
+          expect(response).to redirect_to(activity_record_path(activity_record))
+          expect(flash[:notice]).to eq(success_message)
+        end
+      end
+
+      it 'comment が更新されること' do
+        patch activity_record_path(activity_record), params: update_params
+        expect(activity_record.reload.comment).to eq '更新後のコメント'
+      end
+    end
+
+    context '不正なパラメータのとき（idle_duration > total_duration）' do
+      let(:bad_params) do
+        {
+          activity_record: {
+            idle_duration: 9999,
+            satisfaction:  3, progress: 3, quality: 3, focus: 3, fatigue: 3
+          }
+        }
+      end
+
+      it '422 を返し、エラーメッセージがセットされること' do
+        patch activity_record_path(activity_record), params: bad_params
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+        end
+      end
+    end
+
+    context '他ユーザーのレコードを更新すると' do
+      let(:other_bad_params) do
+        {
+          activity_record: {
+            comment: '改ざん'
+          }
+        }
+      end
+
+      let(:other_activity_record) { create(:activity_record, user: other_user, light_time: other_light_time) }
+
+      it '更新できず 404 を返すこと' do
+        patch activity_record_path(other_activity_record), params: other_bad_params
+        aggregate_failures do
+          expect(response).to have_http_status(:not_found)
+          expect(other_activity_record.reload.comment).not_to eq('改ざん')
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # DELETE /activity_records/:id (destroy)
+  # =========================================================
+  describe 'DELETE /activity_records/:id' do
+    let!(:activity_record) { create(:activity_record, user: user, light_time: light_time) }
+
+    let(:success_message) do
+      I18n.t('defaults.flash_message.deleted', item: ActivityRecord.model_name.human)
+    end
+
+    it 'ActivityRecord が 1 件減ること' do
+      expect { delete activity_record_path(activity_record) }
+        .to change(ActivityRecord, :count).by(-1)
+    end
+
+    it '一覧ページへリダイレクトし、成功メッセージがセットされること' do
+      delete activity_record_path(activity_record)
+      aggregate_failures do
+        expect(response).to redirect_to(activity_records_path)
+        expect(flash[:notice]).to eq(success_message)
+      end
+    end
+
+    context '他ユーザーのレコードに削除すると' do
+      let!(:other_activity_record) { create(:activity_record, user: other_user, light_time: other_light_time) }
+
+      it '削除できず 404 を返すこと' do
+        aggregate_failures do
+          expect {
+            delete activity_record_path(other_activity_record)
+          }.not_to change(ActivityRecord, :count)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -11,332 +11,6 @@ RSpec.describe 'ActivityRecords システムテスト', type: :system do
   end
 
   # =========================================================
-  # 一覧画面 (index)
-  # =========================================================
-  describe '一覧画面' do
-    context '活動記録がないとき' do
-      it '未登録メッセージが表示されること' do
-        visit activity_records_path
-        expect(page).to have_content('光の時間の活動記録が登録されていません')
-      end
-    end
-
-    context '活動記録があるとき' do
-      let!(:activity_record) do
-        create(:activity_record, user: user, light_time: light_time, comment: '集中できた日')
-      end
-
-      it '光の時間の活動内容とコメントが一覧に表示されること' do
-        visit activity_records_path
-        expect(page).to have_content('朝のランニング')
-        expect(page).to have_content('集中できた日')
-      end
-
-      it 'レコードをクリックすると詳細ページへ遷移すること' do
-        visit activity_records_path
-        find('a', text: '朝のランニング').click
-        expect(page).to have_current_path(activity_record_path(activity_record))
-      end
-    end
-
-    context '検索フォームを使ったとき' do
-      before do
-        create(:activity_record, user: user, light_time: light_time, comment: '検索ヒット')
-        create(:activity_record, user: user, light_time: light_time, comment: '対象外')
-      end
-
-      it '検索ワードに一致するレコードだけ表示されること' do
-        visit activity_records_path
-        fill_in 'コメント or 活動内容で検索', with: '検索ヒット'
-        click_on '検索'
-        expect(page).to have_content('検索ヒット')
-        expect(page).not_to have_content('対象外')
-      end
-
-      it '一致しないワードのとき「検索結果が見つかりませんでした」と表示されること' do
-        visit activity_records_path
-        fill_in 'コメント or 活動内容で検索', with: '存在しないキーワード'
-        click_on '検索'
-        expect(page).to have_content('検索結果が見つかりませんでした')
-      end
-    end
-  end
-
-  # =========================================================
-  # 一覧画面（ページネーション）
-  # =========================================================
-  describe '一覧画面（ページネーション）' do
-    context '活動記録が9件以上あるとき' do
-      before do
-        # 9件作成（per_page: 8 を超える件数）
-        9.times do |i|
-          create(:activity_record, user: user, light_time: light_time,comment: "コメント#{i + 1}")
-        end
-        visit activity_records_path
-      end
-
-      it '1ページ目には8件まで表示されること' do
-        # 9件のうち8件のみ表示
-        within('div.space-y-4') do
-          expect(page).to have_selector('.bg-amber-500', count: 8)
-        end
-      end
-
-      it 'ページネーションリンクが表示されること' do
-        expect(page).to have_selector('[data-test="pagination"]')
-      end
-
-      it '2ページ目をクリックすると残りのレコードが表示されること' do
-        click_on '2'
-
-        aggregate_failures do
-          expect(page).to have_current_path(activity_records_path, ignore_query: true)
-          # 9件目（=最も古いレコード）が表示される
-          # created_at: desc 順なので、最初に作ったレコード = 「コメント1」が2ページ目に来る
-          expect(page).to have_content('コメント1')
-        end
-      end
-    end
-
-    context '活動記録が8件以下のとき' do
-      before do
-        create(:activity_record, user: user, light_time: light_time)
-        visit activity_records_path
-      end
-
-      it 'ページネーションリンクが表示されないこと' do
-        expect(page).not_to have_selector('[data-test="pagination"]')
-      end
-    end
-  end
-
-  # =========================================================
-  # 詳細画面 (show)
-  # =========================================================
-  describe '詳細画面' do
-    let!(:activity_record) do
-      create(:activity_record, :high_rating,
-             user: user, light_time: light_time,
-             task: '詳細確認タスク', comment: '詳細コメント',
-             total_duration: 60, idle_duration: 5)
-    end
-
-    before { visit activity_record_path(activity_record) }
-
-    it '各項目が表示されること' do
-      aggregate_failures do
-        expect(page).to have_content('朝のランニング')
-        expect(page).to have_content('詳細確認タスク')
-        expect(page).to have_content('詳細コメント')
-        expect(page).to have_content('60')
-        expect(page).to have_content('5')
-      end
-    end
-
-    it '「編集」リンクが表示されること' do
-      expect(page).to have_link('編集', href: edit_activity_record_path(activity_record))
-    end
-
-    it '「削除」リンクが表示されること' do
-      expect(page).to have_link('削除')
-    end
-  end
-
-  # =========================================================
-  # 登録フロー (new → create)
-  # =========================================================
-  describe '登録フロー' do
-    let(:form_params) do
-      {
-        activity_record_form: {
-          started_at:     1.hour.ago.iso8601,
-          ended_at:       Time.current.iso8601,
-          total_duration: 60,
-          task:           'システムテストタスク',
-          light_time_id:  light_time.id
-        }
-      }
-    end
-
-    before { visit new_activity_record_path(form_params) }
-
-    it '登録フォームが表示されること' do
-      aggregate_failures do
-        expect(page).to have_content('光の時間の活動記録登録')
-        expect(page).to have_content('朝のランニング')
-        expect(page).to have_content('60')
-      end
-    end
-
-    context '評価項目をすべて選択して「記録する」をクリックしたとき' do
-      it '一覧ページへ遷移し、フラッシュメッセージが表示されること' do
-        # rating_field ヘルパーが生成するラジオボタンを選択（value="3"）
-        %w[satisfaction progress quality focus fatigue].each do |attr|
-          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
-        end
-
-        click_on '記録する'
-
-        expect(page).to have_current_path(activity_records_path)
-        expect(page).to have_content(
-          I18n.t('defaults.flash_message.created', item: ActivityRecordForm.model_name.human)
-        )
-      end
-
-      it '浄化タイマー獲得モーダルが表示され、OKをクリックすると閉じること' do
-        %w[satisfaction progress quality focus fatigue].each do |attr|
-          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
-        end
-
-        click_on '記録する'
-
-        # モーダルが表示されている
-        # total_duration: 60 → (60/30).floor * 10 = 20分付与
-        expect(page).to have_content('浄化タイマーを20分獲得！')
-
-        # OKボタンをクリックするとモーダルが閉じる
-        click_on 'OK'
-
-        # closeアクションで display:none になるまで待つ（setTimeoutで300ms）
-        expect(page).to have_selector('[data-controller="modal"]', visible: :hidden, wait: 5)
-      end
-    end
-
-    context 'total_duration が 30分未満で記録したとき' do
-      let(:form_params) do
-        {
-          activity_record_form: {
-            started_at:     1.hour.ago.iso8601,
-            ended_at:       Time.current.iso8601,
-            total_duration: 20,  # ← 30分未満
-            task:           'システムテストタスク',
-            light_time_id:  light_time.id
-          }
-        }
-      end
-
-      it '浄化タイマー獲得モーダルが表示されないこと' do
-        %w[satisfaction progress quality focus fatigue].each do |attr|
-          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
-        end
-
-        click_on '記録する'
-
-        aggregate_failures do
-          expect(page).to have_current_path(activity_records_path)
-          # モーダルのテキストが表示されないこと
-          expect(page).not_to have_content('浄化タイマーを')
-          expect(page).not_to have_content('獲得！')
-        end
-      end
-    end
-
-    context '評価項目を未選択のまま「記録する」をクリックしたとき' do
-      it 'エラーメッセージとフラッシュメッセージが表示されること' do
-        click_on '記録する'
-
-        aggregate_failures do
-          # 各評価項目のエラーメッセージ
-          %w[satisfaction progress quality focus fatigue].each do |attr|
-            expect(page).to have_content('について、1から5のいずれかを選択してください')
-          end
-
-          # フラッシュメッセージ
-          expect(page).to have_content(
-            I18n.t('defaults.flash_message.not_created', item: ActivityRecordForm.model_name.human)
-          )
-
-          # 登録フォームに留まっていること
-          expect(page).to have_current_path(new_activity_record_path, ignore_query: true)
-        end
-      end
-    end
-
-    it '「記録しない」をクリックするとマイページへ遷移すること' do
-      click_on '記録しない'
-      expect(page).to have_current_path(mypage_path)
-    end
-  end
-
-  # =========================================================
-  # 編集フロー (edit → update)
-  # =========================================================
-  describe '編集フロー' do
-    let!(:activity_record) do
-      create(:activity_record, user: user, light_time: light_time, comment: '元のコメント', idle_duration: 0)
-    end
-
-    before { visit edit_activity_record_path(activity_record) }
-
-    it '編集フォームが表示されること' do
-      expect(page).to have_content('光の時間の活動記録編集')
-      expect(page).to have_field('activity_record[comment]', with: '元のコメント')
-    end
-
-    context '正常な値に変更して「更新する」をクリックしたとき' do
-      it '詳細ページへ遷移し、更新後の値が反映されること' do
-        fill_in 'activity_record[comment]', with: '更新後のコメント'
-        click_on '更新する'
-
-        aggregate_failures do
-          expect(page).to have_current_path(activity_record_path(activity_record))
-          expect(page).to have_content(
-            I18n.t('defaults.flash_message.updated', item: ActivityRecord.model_name.human)
-          )
-          expect(page).to have_content('更新後のコメント')
-        end
-      end
-    end
-
-    context '不正な値を入力して「更新する」をクリックしたとき' do
-      it 'エラーメッセージとフラッシュメッセージが表示されること' do
-        # HTML5 バリデーションを無効化してサーバーサイドバリデーションをテスト
-        page.execute_script("document.querySelector('form').setAttribute('novalidate', true)")
-
-        fill_in 'activity_record[idle_duration]', with: 9999
-        click_on '更新する'
-
-        aggregate_failures do
-          expect(page).to have_content('は合計時間以下にしてください')
-          expect(page).to have_content(
-            I18n.t('defaults.flash_message.not_updated', item: ActivityRecord.model_name.human)
-          )
-          expect(page).to have_current_path(edit_activity_record_path(activity_record))
-        end
-      end
-    end
-
-    context '「キャンセル」をクリックしたとき' do
-      it '詳細ページへ戻ること' do
-        click_on 'キャンセル'
-        expect(page).to have_current_path(activity_record_path(activity_record))
-      end
-    end
-  end
-
-  # =========================================================
-  # 削除フロー (show → destroy)
-  # =========================================================
-  describe '削除フロー' do
-    let!(:activity_record) do
-      create(:activity_record, user: user, light_time: light_time, comment: '削除対象')
-    end
-
-    it '削除すると一覧から消えること' do
-      visit activity_record_path(activity_record)
-      accept_confirm { click_on '削除' }
-
-      aggregate_failures do
-        expect(page).to have_current_path(activity_records_path)
-        expect(page).not_to have_content('削除対象')
-        expect(page).to have_content(
-          I18n.t('defaults.flash_message.deleted', item: ActivityRecord.model_name.human)
-        )
-      end
-    end
-  end
-
-  # =========================================================
   # ポモドーロタイマー画面
   # =========================================================
   describe 'ポモドーロタイマー画面' do
@@ -540,6 +214,332 @@ RSpec.describe 'ActivityRecords システムテスト', type: :system do
 
           expect(page).to have_current_path(new_activity_record_path, ignore_query: true, wait: 10)
         end
+      end
+    end
+  end
+
+  # =========================================================
+  # 登録フロー (new → create)
+  # =========================================================
+  describe '登録フロー' do
+    let(:form_params) do
+      {
+        activity_record_form: {
+          started_at:     1.hour.ago.iso8601,
+          ended_at:       Time.current.iso8601,
+          total_duration: 60,
+          task:           'システムテストタスク',
+          light_time_id:  light_time.id
+        }
+      }
+    end
+
+    before { visit new_activity_record_path(form_params) }
+
+    it '登録フォームが表示されること' do
+      aggregate_failures do
+        expect(page).to have_content('光の時間の活動記録登録')
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('60')
+      end
+    end
+
+    context '評価項目をすべて選択して「記録する」をクリックしたとき' do
+      it '一覧ページへ遷移し、フラッシュメッセージが表示されること' do
+        # rating_field ヘルパーが生成するラジオボタンを選択（value="3"）
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        expect(page).to have_current_path(activity_records_path)
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.created', item: ActivityRecordForm.model_name.human)
+        )
+      end
+
+      it '浄化タイマー獲得モーダルが表示され、OKをクリックすると閉じること' do
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        # モーダルが表示されている
+        # total_duration: 60 → (60/30).floor * 10 = 20分付与
+        expect(page).to have_content('浄化タイマーを20分獲得！')
+
+        # OKボタンをクリックするとモーダルが閉じる
+        click_on 'OK'
+
+        # closeアクションで display:none になるまで待つ（setTimeoutで300ms）
+        expect(page).to have_selector('[data-controller="modal"]', visible: :hidden, wait: 5)
+      end
+    end
+
+    context 'total_duration が 30分未満で記録したとき' do
+      let(:form_params) do
+        {
+          activity_record_form: {
+            started_at:     1.hour.ago.iso8601,
+            ended_at:       Time.current.iso8601,
+            total_duration: 20,  # ← 30分未満
+            task:           'システムテストタスク',
+            light_time_id:  light_time.id
+          }
+        }
+      end
+
+      it '浄化タイマー獲得モーダルが表示されないこと' do
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_records_path)
+          # モーダルのテキストが表示されないこと
+          expect(page).not_to have_content('浄化タイマーを')
+          expect(page).not_to have_content('獲得！')
+        end
+      end
+    end
+
+    context '評価項目を未選択のまま「記録する」をクリックしたとき' do
+      it 'エラーメッセージとフラッシュメッセージが表示されること' do
+        click_on '記録する'
+
+        aggregate_failures do
+          # 各評価項目のエラーメッセージ
+          %w[satisfaction progress quality focus fatigue].each do |attr|
+            expect(page).to have_content('について、1から5のいずれかを選択してください')
+          end
+
+          # フラッシュメッセージ
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.not_created', item: ActivityRecordForm.model_name.human)
+          )
+
+          # 登録フォームに留まっていること
+          expect(page).to have_current_path(new_activity_record_path, ignore_query: true)
+        end
+      end
+    end
+
+    it '「記録しない」をクリックするとマイページへ遷移すること' do
+      click_on '記録しない'
+      expect(page).to have_current_path(mypage_path)
+    end
+  end
+
+  # =========================================================
+  # 一覧画面 (index)
+  # =========================================================
+  describe '一覧画面' do
+    context '活動記録がないとき' do
+      it '未登録メッセージが表示されること' do
+        visit activity_records_path
+        expect(page).to have_content('光の時間の活動記録が登録されていません')
+      end
+    end
+
+    context '活動記録があるとき' do
+      let!(:activity_record) do
+        create(:activity_record, user: user, light_time: light_time, comment: '集中できた日')
+      end
+
+      it '光の時間の活動内容とコメントが一覧に表示されること' do
+        visit activity_records_path
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('集中できた日')
+      end
+
+      it 'レコードをクリックすると詳細ページへ遷移すること' do
+        visit activity_records_path
+        find('a', text: '朝のランニング').click
+        expect(page).to have_current_path(activity_record_path(activity_record))
+      end
+    end
+
+    context '検索フォームを使ったとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time, comment: '検索ヒット')
+        create(:activity_record, user: user, light_time: light_time, comment: '対象外')
+      end
+
+      it '検索ワードに一致するレコードだけ表示されること' do
+        visit activity_records_path
+        fill_in 'コメント or 活動内容で検索', with: '検索ヒット'
+        click_on '検索'
+        expect(page).to have_content('検索ヒット')
+        expect(page).not_to have_content('対象外')
+      end
+
+      it '一致しないワードのとき「検索結果が見つかりませんでした」と表示されること' do
+        visit activity_records_path
+        fill_in 'コメント or 活動内容で検索', with: '存在しないキーワード'
+        click_on '検索'
+        expect(page).to have_content('検索結果が見つかりませんでした')
+      end
+    end
+  end
+
+  # =========================================================
+  # 一覧画面（ページネーション）
+  # =========================================================
+  describe '一覧画面（ページネーション）' do
+    context '活動記録が9件以上あるとき' do
+      before do
+        # 9件作成（per_page: 8 を超える件数）
+        9.times do |i|
+          create(:activity_record, user: user, light_time: light_time,comment: "コメント#{i + 1}")
+        end
+        visit activity_records_path
+      end
+
+      it '1ページ目には8件まで表示されること' do
+        # 9件のうち8件のみ表示
+        within('div.space-y-4') do
+          expect(page).to have_selector('.bg-amber-500', count: 8)
+        end
+      end
+
+      it 'ページネーションリンクが表示されること' do
+        expect(page).to have_selector('[data-test="pagination"]')
+      end
+
+      it '2ページ目をクリックすると残りのレコードが表示されること' do
+        click_on '2'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_records_path, ignore_query: true)
+          # 9件目（=最も古いレコード）が表示される
+          # created_at: desc 順なので、最初に作ったレコード = 「コメント1」が2ページ目に来る
+          expect(page).to have_content('コメント1')
+        end
+      end
+    end
+
+    context '活動記録が8件以下のとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time)
+        visit activity_records_path
+      end
+
+      it 'ページネーションリンクが表示されないこと' do
+        expect(page).not_to have_selector('[data-test="pagination"]')
+      end
+    end
+  end
+
+  # =========================================================
+  # 詳細画面 (show)
+  # =========================================================
+  describe '詳細画面' do
+    let!(:activity_record) do
+      create(:activity_record, :high_rating,
+             user: user, light_time: light_time,
+             task: '詳細確認タスク', comment: '詳細コメント',
+             total_duration: 60, idle_duration: 5)
+    end
+
+    before { visit activity_record_path(activity_record) }
+
+    it '各項目が表示されること' do
+      aggregate_failures do
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('詳細確認タスク')
+        expect(page).to have_content('詳細コメント')
+        expect(page).to have_content('60')
+        expect(page).to have_content('5')
+      end
+    end
+
+    it '「編集」リンクが表示されること' do
+      expect(page).to have_link('編集', href: edit_activity_record_path(activity_record))
+    end
+
+    it '「削除」リンクが表示されること' do
+      expect(page).to have_link('削除')
+    end
+  end
+
+  # =========================================================
+  # 編集フロー (edit → update)
+  # =========================================================
+  describe '編集フロー' do
+    let!(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, comment: '元のコメント', idle_duration: 0)
+    end
+
+    before { visit edit_activity_record_path(activity_record) }
+
+    it '編集フォームが表示されること' do
+      expect(page).to have_content('光の時間の活動記録編集')
+      expect(page).to have_field('activity_record[comment]', with: '元のコメント')
+    end
+
+    context '正常な値に変更して「更新する」をクリックしたとき' do
+      it '詳細ページへ遷移し、更新後の値が反映されること' do
+        fill_in 'activity_record[comment]', with: '更新後のコメント'
+        click_on '更新する'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_record_path(activity_record))
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.updated', item: ActivityRecord.model_name.human)
+          )
+          expect(page).to have_content('更新後のコメント')
+        end
+      end
+    end
+
+    context '不正な値を入力して「更新する」をクリックしたとき' do
+      it 'エラーメッセージとフラッシュメッセージが表示されること' do
+        # HTML5 バリデーションを無効化してサーバーサイドバリデーションをテスト
+        page.execute_script("document.querySelector('form').setAttribute('novalidate', true)")
+
+        fill_in 'activity_record[idle_duration]', with: 9999
+        click_on '更新する'
+
+        aggregate_failures do
+          expect(page).to have_content('は合計時間以下にしてください')
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.not_updated', item: ActivityRecord.model_name.human)
+          )
+          expect(page).to have_current_path(edit_activity_record_path(activity_record))
+        end
+      end
+    end
+
+    context '「キャンセル」をクリックしたとき' do
+      it '詳細ページへ戻ること' do
+        click_on 'キャンセル'
+        expect(page).to have_current_path(activity_record_path(activity_record))
+      end
+    end
+  end
+
+  # =========================================================
+  # 削除フロー (show → destroy)
+  # =========================================================
+  describe '削除フロー' do
+    let!(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, comment: '削除対象')
+    end
+
+    it '削除すると一覧から消えること' do
+      visit activity_record_path(activity_record)
+      accept_confirm { click_on '削除' }
+
+      aggregate_failures do
+        expect(page).to have_current_path(activity_records_path)
+        expect(page).not_to have_content('削除対象')
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.deleted', item: ActivityRecord.model_name.human)
+        )
       end
     end
   end

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -1,0 +1,546 @@
+require 'rails_helper'
+
+RSpec.describe 'ActivityRecords システムテスト', type: :system do
+  let(:user) { create(:user) }
+  # 固定文言「朝のランニング」「夜更かししてしまう」をそのまま使う
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before do
+    sign_in user
+  end
+
+  # =========================================================
+  # 一覧画面 (index)
+  # =========================================================
+  describe '一覧画面' do
+    context '活動記録がないとき' do
+      it '未登録メッセージが表示されること' do
+        visit activity_records_path
+        expect(page).to have_content('光の時間の活動記録が登録されていません')
+      end
+    end
+
+    context '活動記録があるとき' do
+      let!(:activity_record) do
+        create(:activity_record, user: user, light_time: light_time, comment: '集中できた日')
+      end
+
+      it '光の時間の活動内容とコメントが一覧に表示されること' do
+        visit activity_records_path
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('集中できた日')
+      end
+
+      it 'レコードをクリックすると詳細ページへ遷移すること' do
+        visit activity_records_path
+        find('a', text: '朝のランニング').click
+        expect(page).to have_current_path(activity_record_path(activity_record))
+      end
+    end
+
+    context '検索フォームを使ったとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time, comment: '検索ヒット')
+        create(:activity_record, user: user, light_time: light_time, comment: '対象外')
+      end
+
+      it '検索ワードに一致するレコードだけ表示されること' do
+        visit activity_records_path
+        fill_in 'コメント or 活動内容で検索', with: '検索ヒット'
+        click_on '検索'
+        expect(page).to have_content('検索ヒット')
+        expect(page).not_to have_content('対象外')
+      end
+
+      it '一致しないワードのとき「検索結果が見つかりませんでした」と表示されること' do
+        visit activity_records_path
+        fill_in 'コメント or 活動内容で検索', with: '存在しないキーワード'
+        click_on '検索'
+        expect(page).to have_content('検索結果が見つかりませんでした')
+      end
+    end
+  end
+
+  # =========================================================
+  # 一覧画面（ページネーション）
+  # =========================================================
+  describe '一覧画面（ページネーション）' do
+    context '活動記録が9件以上あるとき' do
+      before do
+        # 9件作成（per_page: 8 を超える件数）
+        9.times do |i|
+          create(:activity_record, user: user, light_time: light_time,comment: "コメント#{i + 1}")
+        end
+        visit activity_records_path
+      end
+
+      it '1ページ目には8件まで表示されること' do
+        # 9件のうち8件のみ表示
+        within('div.space-y-4') do
+          expect(page).to have_selector('.bg-amber-500', count: 8)
+        end
+      end
+
+      it 'ページネーションリンクが表示されること' do
+        expect(page).to have_selector('[data-test="pagination"]')
+      end
+
+      it '2ページ目をクリックすると残りのレコードが表示されること' do
+        click_on '2'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_records_path, ignore_query: true)
+          # 9件目（=最も古いレコード）が表示される
+          # created_at: desc 順なので、最初に作ったレコード = 「コメント1」が2ページ目に来る
+          expect(page).to have_content('コメント1')
+        end
+      end
+    end
+
+    context '活動記録が8件以下のとき' do
+      before do
+        create(:activity_record, user: user, light_time: light_time)
+        visit activity_records_path
+      end
+
+      it 'ページネーションリンクが表示されないこと' do
+        expect(page).not_to have_selector('[data-test="pagination"]')
+      end
+    end
+  end
+
+  # =========================================================
+  # 詳細画面 (show)
+  # =========================================================
+  describe '詳細画面' do
+    let!(:activity_record) do
+      create(:activity_record, :high_rating,
+             user: user, light_time: light_time,
+             task: '詳細確認タスク', comment: '詳細コメント',
+             total_duration: 60, idle_duration: 5)
+    end
+
+    before { visit activity_record_path(activity_record) }
+
+    it '各項目が表示されること' do
+      aggregate_failures do
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('詳細確認タスク')
+        expect(page).to have_content('詳細コメント')
+        expect(page).to have_content('60')
+        expect(page).to have_content('5')
+      end
+    end
+
+    it '「編集」リンクが表示されること' do
+      expect(page).to have_link('編集', href: edit_activity_record_path(activity_record))
+    end
+
+    it '「削除」リンクが表示されること' do
+      expect(page).to have_link('削除')
+    end
+  end
+
+  # =========================================================
+  # 登録フロー (new → create)
+  # =========================================================
+  describe '登録フロー' do
+    let(:form_params) do
+      {
+        activity_record_form: {
+          started_at:     1.hour.ago.iso8601,
+          ended_at:       Time.current.iso8601,
+          total_duration: 60,
+          task:           'システムテストタスク',
+          light_time_id:  light_time.id
+        }
+      }
+    end
+
+    before { visit new_activity_record_path(form_params) }
+
+    it '登録フォームが表示されること' do
+      aggregate_failures do
+        expect(page).to have_content('光の時間の活動記録登録')
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('60')
+      end
+    end
+
+    context '評価項目をすべて選択して「記録する」をクリックしたとき' do
+      it '一覧ページへ遷移し、フラッシュメッセージが表示されること' do
+        # rating_field ヘルパーが生成するラジオボタンを選択（value="3"）
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        expect(page).to have_current_path(activity_records_path)
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.created', item: ActivityRecordForm.model_name.human)
+        )
+      end
+
+      it '浄化タイマー獲得モーダルが表示され、OKをクリックすると閉じること' do
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        # モーダルが表示されている
+        # total_duration: 60 → (60/30).floor * 10 = 20分付与
+        expect(page).to have_content('浄化タイマーを20分獲得！')
+
+        # OKボタンをクリックするとモーダルが閉じる
+        click_on 'OK'
+
+        # closeアクションで display:none になるまで待つ（setTimeoutで300ms）
+        expect(page).to have_selector('[data-controller="modal"]', visible: :hidden, wait: 5)
+      end
+    end
+
+    context 'total_duration が 30分未満で記録したとき' do
+      let(:form_params) do
+        {
+          activity_record_form: {
+            started_at:     1.hour.ago.iso8601,
+            ended_at:       Time.current.iso8601,
+            total_duration: 20,  # ← 30分未満
+            task:           'システムテストタスク',
+            light_time_id:  light_time.id
+          }
+        }
+      end
+
+      it '浄化タイマー獲得モーダルが表示されないこと' do
+        %w[satisfaction progress quality focus fatigue].each do |attr|
+          find("input[name='activity_record_form[#{attr}]'][value='3']").choose
+        end
+
+        click_on '記録する'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_records_path)
+          # モーダルのテキストが表示されないこと
+          expect(page).not_to have_content('浄化タイマーを')
+          expect(page).not_to have_content('獲得！')
+        end
+      end
+    end
+
+    context '評価項目を未選択のまま「記録する」をクリックしたとき' do
+      it 'エラーメッセージとフラッシュメッセージが表示されること' do
+        click_on '記録する'
+
+        aggregate_failures do
+          # 各評価項目のエラーメッセージ
+          %w[satisfaction progress quality focus fatigue].each do |attr|
+            expect(page).to have_content('について、1から5のいずれかを選択してください')
+          end
+
+          # フラッシュメッセージ
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.not_created', item: ActivityRecordForm.model_name.human)
+          )
+
+          # 登録フォームに留まっていること
+          expect(page).to have_current_path(new_activity_record_path, ignore_query: true)
+        end
+      end
+    end
+
+    it '「記録しない」をクリックするとマイページへ遷移すること' do
+      click_on '記録しない'
+      expect(page).to have_current_path(mypage_path)
+    end
+  end
+
+  # =========================================================
+  # 編集フロー (edit → update)
+  # =========================================================
+  describe '編集フロー' do
+    let!(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, comment: '元のコメント', idle_duration: 0)
+    end
+
+    before { visit edit_activity_record_path(activity_record) }
+
+    it '編集フォームが表示されること' do
+      expect(page).to have_content('光の時間の活動記録編集')
+      expect(page).to have_field('activity_record[comment]', with: '元のコメント')
+    end
+
+    context '正常な値に変更して「更新する」をクリックしたとき' do
+      it '詳細ページへ遷移し、更新後の値が反映されること' do
+        fill_in 'activity_record[comment]', with: '更新後のコメント'
+        click_on '更新する'
+
+        aggregate_failures do
+          expect(page).to have_current_path(activity_record_path(activity_record))
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.updated', item: ActivityRecord.model_name.human)
+          )
+          expect(page).to have_content('更新後のコメント')
+        end
+      end
+    end
+
+    context '不正な値を入力して「更新する」をクリックしたとき' do
+      it 'エラーメッセージとフラッシュメッセージが表示されること' do
+        # HTML5 バリデーションを無効化してサーバーサイドバリデーションをテスト
+        page.execute_script("document.querySelector('form').setAttribute('novalidate', true)")
+
+        fill_in 'activity_record[idle_duration]', with: 9999
+        click_on '更新する'
+
+        aggregate_failures do
+          expect(page).to have_content('は合計時間以下にしてください')
+          expect(page).to have_content(
+            I18n.t('defaults.flash_message.not_updated', item: ActivityRecord.model_name.human)
+          )
+          expect(page).to have_current_path(edit_activity_record_path(activity_record))
+        end
+      end
+    end
+
+    context '「キャンセル」をクリックしたとき' do
+      it '詳細ページへ戻ること' do
+        click_on 'キャンセル'
+        expect(page).to have_current_path(activity_record_path(activity_record))
+      end
+    end
+  end
+
+  # =========================================================
+  # 削除フロー (show → destroy)
+  # =========================================================
+  describe '削除フロー' do
+    let!(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, comment: '削除対象')
+    end
+
+    it '削除すると一覧から消えること' do
+      visit activity_record_path(activity_record)
+      accept_confirm { click_on '削除' }
+
+      aggregate_failures do
+        expect(page).to have_current_path(activity_records_path)
+        expect(page).not_to have_content('削除対象')
+        expect(page).to have_content(
+          I18n.t('defaults.flash_message.deleted', item: ActivityRecord.model_name.human)
+        )
+      end
+    end
+  end
+
+  # =========================================================
+  # ポモドーロタイマー画面
+  # =========================================================
+  describe 'ポモドーロタイマー画面' do
+    before { visit pomodoro_timer_activity_records_path }
+
+    it 'タイマー画面が表示されること' do
+      aggregate_failures do
+        expect(page).to have_content('25:00')
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('健康的な自分')
+      end
+    end
+
+    it 'スタートボタンと終了するボタンが表示されること' do
+      aggregate_failures do
+        expect(page).to have_button('スタート')
+        expect(page).to have_button('終了する')
+      end
+    end
+
+    it 'スタートせずに「終了する」をクリックするとアラートが表示されること' do
+      accept_alert('スタートボタンを押してください') do
+        click_on '終了する', visible: true
+      end
+    end
+
+    it '「集中できない、やる気が出ないときは」をクリックするとモチベーション画面が表示されること' do
+      click_on '集中できない、やる気が出ないときは', visible: true
+      expect(page).to have_selector('[data-pomodoro-target="motivationScreen"]:not(.hidden)')
+      expect(page).to have_selector('[data-pomodoro-target="workScreen"].hidden')
+      expect(page).to have_content('夜更かししてしまう')
+      expect(page).to have_content('健康を損なう')
+    end
+
+    it 'モチベーション画面で「いいえ、もう少し頑張ります！」をクリックすると作業画面に戻ること' do
+      click_on '集中できない、やる気が出ないときは', visible: true
+      click_on 'いいえ、もう少し頑張ります！'
+      expect(page).to have_selector('[data-pomodoro-target="workScreen"]:not(.hidden)')
+      expect(page).to have_selector('[data-pomodoro-target="motivationScreen"].hidden')
+      expect(page).to have_content('25:00')
+      expect(page).to have_button('スタート')
+    end
+
+    context 'やること入力フォームに入力して「更新する」をクリックしたとき' do
+      it 'やること表示エリアが入力内容に更新されること' do
+        fill_in 'やることを入力', with: '今日のタスク'
+        click_on '更新する'
+        expect(page).to have_content('今日のタスク')
+      end
+    end
+  end
+
+  # =========================================================
+  # ポモドーロタイマー動作中
+  # =========================================================
+  describe 'ポモドーロタイマー動作中' do
+    before do
+      visit pomodoro_timer_activity_records_path
+      # Stimulus の value を直接書き換えてタイマーを短縮
+      # work: 3秒、break: 2秒 に設定
+      page.execute_script(<<~JS)
+        const el = document.querySelector('[data-controller="pomodoro"]')
+        el.dataset.pomodoroWorkDurationValue = 3
+        el.dataset.pomodoroBreakDurationValue = 2
+      JS
+    end
+
+    context 'スタートボタンをクリックしたとき' do
+      it 'スタートボタンが非表示になりタイマーが動き始めること' do
+        click_on 'スタート', visible: true
+        aggregate_failures do
+          expect(page).not_to have_button('スタート', visible: true)
+          expect(page).to have_content('00:02', wait: 3)
+        end
+      end
+    end
+
+    context '作業時間が終了したとき' do
+      it '休憩画面に切り替わりポモドーロ数が1になること' do
+        click_on 'スタート', visible: true
+
+        aggregate_failures do
+          # 1. 休憩画面（breakScreenターゲット）が目に見える状態になっていること
+          expect(page).to have_selector('[data-pomodoro-target="breakScreen"]:not(.hidden)', wait: 10)
+
+          # 2. 作業画面（workScreenターゲット）が非表示になっていること
+          expect(page).to have_selector('[data-pomodoro-target="workScreen"].hidden')
+
+          # 3. ポモドーロ数のカウントアップを確認
+          expect(page).to have_content('ポモドーロ数：1', wait: 10)
+
+          # 4. 休憩画面の中身を網羅的に検証
+          within('[data-pomodoro-target="breakScreen"]') do
+            expect(page).to have_css('img[src*="timer"]') # timer.png があるか
+            expect(page).to have_button('集中できない、やる気が出ないときは', visible: true)
+            expect(page).to have_button('終了する', visible: true)
+          end
+        end
+      end
+    end
+
+    context '休憩時間が終了したとき' do
+      it '作業画面に戻りスタートボタンが表示されること' do
+        click_on 'スタート', visible: true
+        aggregate_failures do
+          # 作業3秒 + 休憩2秒 終了後にスタートボタンが再表示される
+          expect(page).to have_button('スタート', wait: 15)
+          expect(page).to have_content('ポモドーロ数：1', wait: 15)
+        end
+      end
+    end
+
+    # =========================================================
+    # 無操作タイムアウト（2回目以降のセッション）
+    # =========================================================
+    context '2回目以降のセッションで無操作タイムアウトが発生したとき' do
+      before do
+        # 無操作タイムアウトも短縮（2秒）、チェック間隔も短縮（0.5秒）
+        page.execute_script(<<~JS)
+          const el = document.querySelector('[data-controller="pomodoro"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(el, 'pomodoro')
+          controller.inactivityTimeout = 2000  // タイムアウト2秒
+          controller.checkInterval = 500       // 0.5秒ごとにチェック
+        JS
+
+        # 1回目のポモドーロを完了させて休憩画面へ
+        click_on 'スタート', visible: true
+
+        # 作業時間（3秒）終了を待つ → 休憩画面へ切り替わる
+        expect(page).to have_selector('[data-pomodoro-target="breakScreen"]:not(.hidden)', wait: 10)
+        # 休憩時間（2秒）終了を待つ → 作業画面に戻りスタートボタンが表示される
+        expect(page).to have_button('スタート', wait: 10)
+        # この時点で inactivityCheck が開始されている
+      end
+
+      it '無操作タイムアウト後に自動で新規作成画面へ遷移すること' do
+        accept_alert(wait: 10)
+        expect(page).to have_current_path(new_activity_record_path, ignore_query: true, wait: 10)
+      end
+      # ✕ テストせず目視で確認する：タイムアウト時間の正確性（20分かどうか）
+      # 手動の動作確認で担保
+    end
+
+    # =========================================================
+    # 終了ボタン後に新規作成画面へ遷移
+    # =========================================================
+    describe '終了ボタンをクリックしたとき' do
+      before do
+        visit pomodoro_timer_activity_records_path
+        # Stimulus の value を直接書き換えてタイマーを短縮
+        # work: 3秒、break: 2秒 に設定
+        page.execute_script(<<~JS)
+          const el = document.querySelector('[data-controller="pomodoro"]')
+          el.dataset.pomodoroWorkDurationValue = 3
+          el.dataset.pomodoroBreakDurationValue = 2
+        JS
+      end
+
+      context '作業画面から終了したとき' do
+        it 'スタート後に終了すると新規作成画面へ遷移すること' do
+          click_on 'スタート', visible: true
+          # スタート直後はタイマーが動いているので startButton が hidden になることを確認
+          expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+
+          # 作業画面の終了ボタンを直接クリック（アラートは出ない）
+          within('[data-pomodoro-target="workScreen"]') do
+            click_on '終了する', visible: true
+          end
+
+          expect(page).to have_current_path(new_activity_record_path, ignore_query: true, wait: 10)
+        end
+      end
+
+      context '休憩画面から終了したとき' do
+        before do
+          click_on 'スタート', visible: true
+          # 作業時間終了を待つ → 休憩画面へ
+          expect(page).to have_selector('[data-pomodoro-target="breakScreen"]:not(.hidden)', wait: 10)
+        end
+
+        it '新規作成画面へ遷移すること' do
+          within('[data-pomodoro-target="breakScreen"]') do
+            click_on '終了する', visible: true
+          end
+
+          expect(page).to have_current_path(new_activity_record_path, ignore_query: true, wait: 10)
+        end
+      end
+
+      context 'モチベーション画面の「それでいいもん」をクリックしたとき' do
+        before do
+          click_on 'スタート', visible: true
+          within('[data-pomodoro-target="workScreen"]') do
+            click_on '集中できない、やる気が出ないときは', visible: true
+          end
+          expect(page).to have_selector('[data-pomodoro-target="motivationScreen"]:not(.hidden)', wait: 5)
+        end
+
+        it '新規作成画面へ遷移すること' do
+          click_on 'それでいいもん'
+
+          expect(page).to have_current_path(new_activity_record_path, ignore_query: true, wait: 10)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/shared/hamburger_menu_spec.rb
+++ b/spec/system/shared/hamburger_menu_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'ハンバーガーメニュー', type: :system do
+  let(:user) { create(:user) }
+  # ハンバーガーメニューはマイページに dark_time と light_time の両方がある時のみ表示される
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before do
+    sign_in user
+    visit mypage_path
+  end
+
+  describe '開閉動作' do
+    it '初期状態ではメニューが閉じていること' do
+      # メニューは translate-x-full で画面外に隠されている
+      expect(page).to have_selector('[data-hamburger-target="menu"].-translate-x-full')
+    end
+
+    context 'ハンバーガーボタンをクリックしたとき' do
+      it 'メニューが開くこと' do
+        find('[data-hamburger-target="button"]').click
+        # 開いた後は -translate-x-full クラスが外れる
+        expect(page).not_to have_selector('[data-hamburger-target="menu"].-translate-x-full', wait: 5)
+      end
+
+      it 'オーバーレイが表示されること' do
+        find('[data-hamburger-target="button"]').click
+        expect(page).to have_selector('[data-hamburger-target="overlay"]:not(.hidden)', wait: 5)
+      end
+    end
+
+    context 'メニューが開いているときにハンバーガーボタンを再度クリックしたとき' do
+      before { find('[data-hamburger-target="button"]').click }
+
+      it 'メニューが閉じること' do
+        # 一度開いた状態を確認してから再クリック
+        expect(page).not_to have_selector('[data-hamburger-target="menu"].-translate-x-full', wait: 5)
+
+        find('[data-hamburger-target="button"]').click
+
+        aggregate_failures do
+          expect(page).to have_selector('[data-hamburger-target="menu"].-translate-x-full', wait: 5)
+          expect(page).to have_selector('[data-hamburger-target="overlay"].hidden', wait: 5)
+        end
+      end
+    end
+
+    context 'オーバーレイをクリックしたとき' do
+      before { find('[data-hamburger-target="button"]').click }
+
+      it 'メニューが閉じること' do
+        find('[data-hamburger-target="overlay"]').click
+        expect(page).to have_selector('[data-hamburger-target="menu"].-translate-x-full', wait: 5)
+      end
+    end
+  end
+
+  describe 'メニュー内のリンク' do
+    before { find('[data-hamburger-target="button"]').click }
+
+    it '「マイページ」リンクをクリックするとマイページへ遷移すること' do
+      within('[data-hamburger-target="menu"]') do
+        click_on 'マイページ'
+      end
+      expect(page).to have_current_path(mypage_path)
+    end
+
+    it '「活動記録」リンクをクリックすると一覧ページへ遷移すること' do
+      within('[data-hamburger-target="menu"]') do
+        click_on '活動記録'
+      end
+      expect(page).to have_current_path(activity_records_path)
+    end
+  end
+end


### PR DESCRIPTION
# 概要
活動時間の計測&活動記録新規登録、詳細、編集、削除機能、検索機能、ページネーションのテストコードの作成を行います。

- [x] カラムのモデルスペックの作成
- [x] 光の時間の活動記録の新規登録機能に関するテストコードの作成
- [x] 光の時間の活動記録の一覧画面に関するテストコードの作成
- [x] システムスペックにおいてポモドーロタイマーに関する以下のテストケースを追加：
  - [x] ポモドーロタイマー画面
  - [x] ポモドーロタイマー動作中
  - [x] 無操作タイムアウト（2回目以降のセッション）、ただし、自動で新規登録フォームに遷移する処理のみ記述。タイムアウト時間が含んでいないことは、テストせず目視で確認することにした
  - [x] 終了ボタン後に新規作成画面へ遷移
- [x] 光の時間の活動記録の詳細画面に関するテストコードの作成
- [x] 光の時間の活動記録の編集機能に関するテストコードの作成
- [x] 光の時間の活動記録の削除機能に関するテストコードの作成
- [x] 光の時間の活動記録の検索機能に関するテストコードの作成
- [x] 光の時間の活動記録のページネーションに関するテストコードの作成

### 補足事項
- ある１つのブラウザのタブで活動記録新規登録フォームを記入時に、別タブで光の時間の活動内容を切り替えた際に、「記録する」ボタンをクリックすると、fuzzy read な挙動が見られた。そのため、活動記録フォームにおいて、light_time を is_currentではなく、ポモドーロタイマーの画面表示時に、light_time_idを取得して、活動記録のcreateアクションまでlight_time_idを渡す実装に変更した
- ページネーションの挙動を確認するため、data-test属性を追加。また、total_pagesによる条件分岐を追加
- 浄化タイマーのテーブルを含め、関連付けの登録を行った