### PR TITLE
add: 浄化タイマーのテストコードを追加

### DIFF
--- a/app/javascript/controllers/purification_timer_controller.js
+++ b/app/javascript/controllers/purification_timer_controller.js
@@ -84,10 +84,11 @@ export default class extends Controller {
   }
 
   request(url, redirect = false) {
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
     fetch(url, {
       method: "PATCH",
       headers: {
-        "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
+        "X-CSRF-Token": csrfToken || ""
       }
     }).then(() => {
       if (redirect) {

--- a/app/views/purification_times/show.html.erb
+++ b/app/views/purification_times/show.html.erb
@@ -33,12 +33,12 @@
       <%= link_to "マイページに戻る", mypage_path, class: "bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
     </div>
   <% elsif @purification_time.idle? || @purification_time.paused? %>
-  <div class="flex justify-center gap-6">
+    <div class="flex justify-center gap-6">
       <button type="button" data-action="click->purification-timer#start" class="bg-green-700 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-green-800 transition duration-200">
-          スタート
-        </button>
-        <%= link_to "キャンセル", mypage_path, class: "bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
-      </div>
+        スタート
+      </button>
+      <%= link_to "キャンセル", mypage_path, class: "bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
+    </div>
   <% elsif @purification_time.running? %>
     <button type="button" data-action="click->purification-timer#stop" class="bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200">
       終了する

--- a/spec/factories/purification_times.rb
+++ b/spec/factories/purification_times.rb
@@ -1,7 +1,34 @@
 FactoryBot.define do
   factory :purification_time do
+    status { :idle }
     remaining_time { 0 }
+    total_time { 0 }
+    started_at { nil }
+    paused_at { nil }
 
     association :user
+
+    # 浄化タイマーが付与済みでスタート前の状態
+    trait :idle_with_time do
+      status { :idle }
+      remaining_time { 600 } # 10分
+    end
+
+    # 実行中
+    trait :running do
+      status { :running }
+      remaining_time { 600 }
+      total_time { 600 }
+      started_at { Time.current }
+    end
+
+    # 一時停止中
+    trait :paused do
+      status { :paused }
+      remaining_time { 300 }
+      total_time { 600 }
+      started_at { 5.minutes.ago }
+      paused_at { Time.current }
+    end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,65 @@
+# spec/helpers/application_helper_spec.rb
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#format_seconds_to_mmss' do
+    it '60秒を「1 分 00 秒」に変換すること' do
+      expect(helper.format_seconds_to_mmss(60)).to eq '1 分 00 秒'
+    end
+
+    it '125秒を「2 分 05 秒」に変換すること(秒のゼロパディング)' do
+      expect(helper.format_seconds_to_mmss(125)).to eq '2 分 05 秒'
+    end
+
+    it '0秒を「0 分 00 秒」に変換すること' do
+      expect(helper.format_seconds_to_mmss(0)).to eq '0 分 00 秒'
+    end
+
+    it '3600秒を「60 分 00 秒」に変換すること' do
+      expect(helper.format_seconds_to_mmss(3600)).to eq '60 分 00 秒'
+    end
+  end
+
+  describe '#format_minutes_to_hm' do
+    it '60分を「1 時間 00 分」に変換すること' do
+      expect(helper.format_minutes_to_hm(60)).to eq '1 時間 00 分'
+    end
+
+    it '125分を「2 時間 05 分」に変換すること' do
+      expect(helper.format_minutes_to_hm(125)).to eq '2 時間 05 分'
+    end
+
+    it '0分を「0 時間 00 分」に変換すること' do
+      expect(helper.format_minutes_to_hm(0)).to eq '0 時間 00 分'
+    end
+  end
+
+  describe '#display_percentage' do
+    it 'nil のとき「未設定」を返すこと' do
+      expect(helper.display_percentage(nil)).to eq '未設定'
+    end
+
+    it '0.8 を「80 %」に変換すること' do
+      expect(helper.display_percentage(0.8)).to eq '80 %'
+    end
+
+    it '0.125 を「13 %」に変換すること(四捨五入)' do
+      expect(helper.display_percentage(0.125)).to eq '13 %'
+    end
+
+    it '1.0 を「100 %」に変換すること' do
+      expect(helper.display_percentage(1.0)).to eq '100 %'
+    end
+  end
+
+  describe '#format_datetime' do
+    it 'DateTime をフォーマットすること' do
+      dt = Time.zone.local(2024, 1, 15, 14, 30)
+      expect(helper.format_datetime(dt)).to eq '2024-01-15 14:30'
+    end
+
+    it 'nil のとき nil を返すこと' do
+      expect(helper.format_datetime(nil)).to be_nil
+    end
+  end
+end

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -190,24 +190,48 @@ RSpec.describe ActivityRecord, type: :model do
   # after_create: grant_purification_time
   # =========================================================
   describe 'grant_purification_time コールバック' do
-    let!(:purification_time) { create(:purification_time, user: user, remaining_time: 0) }
+    context 'PurificationTime が既に存在するとき' do
+      let!(:purification_time) { create(:purification_time, user: user, remaining_time: 0) }
 
-    context ':long_session（90 分）のとき' do
-      it 'remaining_time に 1800 秒（30 分）加算されること' do
-        # (90 / 30).floor * 10 = 30 分付与 → 30 * 60 = 1800 秒
-        create(:activity_record, :long_session, user: user, light_time: light_time)
-        expect(purification_time.reload.remaining_time).to eq 1800
+      context ':long_session (90 分) のとき' do
+        it 'remaining_time に 1800 秒 (30 分) 加算されること' do
+          create(:activity_record, :long_session, user: user, light_time: light_time)
+          expect(purification_time.reload.remaining_time).to eq 1800
+        end
+      end
+
+      context ':short_session (20 分) のとき' do
+        it 'remaining_time が変化しないこと' do
+          create(:activity_record, :short_session, user: user, light_time: light_time)
+          expect(purification_time.reload.remaining_time).to eq 0
+        end
       end
     end
 
-    context ':short_session（20 分）のとき' do
-      it 'remaining_time が変化しないこと' do
-        create(:activity_record, :short_session, user: user, light_time: light_time)
-        expect(purification_time.reload.remaining_time).to eq 0
+    context 'PurificationTime がまだ存在しないとき' do
+      context ':long_session (90 分) のとき' do
+        it 'PurificationTime が新規作成されて 1800 秒セットされること' do
+          expect {
+            create(:activity_record, :long_session, user: user, light_time: light_time)
+          }.to change(PurificationTime, :count).by(1)
+
+          expect(user.reload.purification_time.remaining_time).to eq 1800
+        end
+      end
+
+      context ':short_session (20 分) のとき' do
+        it 'PurificationTime は作成されないこと' do
+          expect {
+            create(:activity_record, :short_session, user: user, light_time: light_time)
+          }.not_to change(PurificationTime, :count)
+        end
       end
     end
   end
 
+  # =========================================================
+  # ransack の検索可能カラム
+  # =========================================================
   describe 'ransack の検索可能カラム' do
     it '検索可能なカラムが comment のみであること' do
       expect(described_class.ransackable_attributes).to eq ['comment']

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -31,48 +31,48 @@ RSpec.describe ActivityRecord, type: :model do
     end
 
     describe 'idle_duration' do
-      subject(:record) { build(:activity_record, user: user, light_time: light_time) }
+      subject(:activity_record) { build(:activity_record, user: user, light_time: light_time) }
 
       it '0 は有効' do
-        record.idle_duration = 0
-        expect(record).to be_valid
+        activity_record.idle_duration = 0
+        expect(activity_record).to be_valid
       end
 
       it '負の値は無効' do
-        record.idle_duration = -1
-        expect(record).to be_invalid
-        expect(record.errors[:idle_duration]).to be_present
+        activity_record.idle_duration = -1
+        expect(activity_record).to be_invalid
+        expect(activity_record.errors[:idle_duration]).to be_present
       end
 
       it 'total_duration を超えると無効' do
-        record.idle_duration = record.total_duration + 1
-        expect(record).to be_invalid
-        expect(record.errors[:idle_duration]).to include('は合計時間以下にしてください')
+        activity_record.idle_duration = activity_record.total_duration + 1
+        expect(activity_record).to be_invalid
+        expect(activity_record.errors[:idle_duration]).to include('は合計時間以下にしてください')
       end
 
       it 'total_duration と同値は有効' do
-        record.idle_duration = record.total_duration
-        expect(record).to be_valid
+        activity_record.idle_duration = activity_record.total_duration
+        expect(activity_record).to be_valid
       end
     end
 
     describe '5段階評価カラム' do
-      subject(:record) { build(:activity_record, user: user, light_time: light_time) }
+      subject(:activity_record) { build(:activity_record, user: user, light_time: light_time) }
 
       %i[satisfaction progress quality focus fatigue].each do |attr|
         context attr.to_s do
           (1..5).each do |v|
             it "#{v} は有効" do
-              record.send(:"#{attr}=", v)
-              expect(record).to be_valid
+              activity_record.send(:"#{attr}=", v)
+              expect(activity_record).to be_valid
             end
           end
 
           [0, 6].each do |v|
             it "#{v} は無効" do
-              record.send(:"#{attr}=", v)
-              expect(record).to be_invalid
-              expect(record.errors[attr]).to be_present
+              activity_record.send(:"#{attr}=", v)
+              expect(activity_record).to be_invalid
+              expect(activity_record.errors[attr]).to be_present
             end
           end
         end
@@ -166,23 +166,23 @@ RSpec.describe ActivityRecord, type: :model do
   # =========================================================
   describe 'desired_self_percentage の計算' do
     it '正しい割合が保存されること' do
-      record = create(:activity_record, user: user, light_time: light_time,
+      activity_record = create(:activity_record, user: user, light_time: light_time,
                       total_duration: 100, idle_duration: 20)
       # (100 - 20) / 100.0 = 0.8
-      expect(record.desired_self_percentage).to be_within(0.001).of(0.8)
+      expect(activity_record.desired_self_percentage).to be_within(0.001).of(0.8)
     end
 
     it 'idle_duration が 0 のとき 1.0 になること' do
-      record = create(:activity_record, user: user, light_time: light_time,
+      activity_record = create(:activity_record, user: user, light_time: light_time,
                       total_duration: 60, idle_duration: 0)
-      expect(record.desired_self_percentage).to be_within(0.001).of(1.0)
+      expect(activity_record.desired_self_percentage).to be_within(0.001).of(1.0)
     end
 
     it 'total_duration が 0 のときは nil のままであること' do
-      record = build(:activity_record, user: user, light_time: light_time,
+      activity_record = build(:activity_record, user: user, light_time: light_time,
                      total_duration: 0, idle_duration: 0)
-      record.save(validate: false)
-      expect(record.desired_self_percentage).to be_nil
+      activity_record.save(validate: false)
+      expect(activity_record.desired_self_percentage).to be_nil
     end
   end
 

--- a/spec/models/purification_time_spec.rb
+++ b/spec/models/purification_time_spec.rb
@@ -1,10 +1,197 @@
 require 'rails_helper'
 
 RSpec.describe PurificationTime, type: :model do
+  # =========================================================
+  # アソシエーション
+  # =========================================================
   describe 'アソシエーション' do
     it 'User に属していること' do
       association = described_class.reflect_on_association(:user)
       expect(association.macro).to eq :belongs_to
+    end
+  end
+
+  # =========================================================
+  # enum
+  # =========================================================
+  describe 'enum status' do
+    it 'idle / running / paused が定義されていること' do
+      expect(described_class.statuses).to eq(
+        'idle' => 0, 'running' => 1, 'paused' => 2
+      )
+    end
+  end
+
+  # =========================================================
+  # #finished?
+  # =========================================================
+  describe '#finished?' do
+    let(:purification_time) { build(:purification_time, remaining_time: remaining) }
+
+    context 'remaining_time が 0 のとき' do
+      let(:remaining) { 0 }
+      it { expect(purification_time.finished?).to be true }
+    end
+
+    context 'remaining_time が 負の値のとき' do
+      let(:remaining) { -10 }
+      it { expect(purification_time.finished?).to be true }
+    end
+
+    context 'remaining_time が 正の値のとき' do
+      let(:remaining) { 600 }
+      it { expect(purification_time.finished?).to be false }
+    end
+  end
+
+  # =========================================================
+  # #start!
+  # =========================================================
+  describe '#start!' do
+    context 'idle 状態のとき' do
+      let(:purification_time) { create(:purification_time, :idle_with_time) }
+
+      it 'running 状態になること' do
+        purification_time.start!
+        expect(purification_time.reload).to be_running
+      end
+
+      it 'started_at がセットされること' do
+        freeze_time do
+          purification_time.start!
+          expect(purification_time.reload.started_at).to be_within(1.second).of(Time.current)
+        end
+      end
+
+      it 'total_time に remaining_time の値がセットされること' do
+        purification_time.start!
+        expect(purification_time.reload.total_time).to eq 600
+      end
+    end
+
+    context 'paused 状態のとき' do
+      let(:purification_time) { create(:purification_time, :paused) }
+
+      it 'running 状態になること' do
+        purification_time.start!
+        expect(purification_time.reload).to be_running
+      end
+
+      it 'total_time が再開時の remaining_time で更新されること' do
+        purification_time.start!
+        expect(purification_time.reload.total_time).to eq 300
+      end
+    end
+
+    context 'running 状態のとき' do
+      let(:purification_time) { create(:purification_time, :running) }
+
+      it '何も更新されないこと' do
+        expect { purification_time.start! }.not_to change { purification_time.reload.updated_at }
+      end
+    end
+  end
+
+  # =========================================================
+  # #stop!
+  # =========================================================
+  describe '#stop!' do
+    context 'running 状態で残り時間があるとき' do
+      let(:purification_time) do
+        create(:purification_time,
+               status: :running,
+               remaining_time: 600,
+               total_time: 600,
+               started_at: 3.minutes.ago)
+      end
+
+      it 'paused 状態になること' do
+        purification_time.stop!
+        expect(purification_time.reload).to be_paused
+      end
+
+      it 'remaining_time が経過分減ること' do
+        purification_time.stop!
+        # 600秒 - 180秒 = 420秒前後
+        expect(purification_time.reload.remaining_time).to be_within(2).of(420)
+      end
+
+      it 'paused_at がセットされること' do
+        freeze_time do
+          purification_time.stop!
+          expect(purification_time.reload.paused_at).to be_within(1.second).of(Time.current)
+        end
+      end
+    end
+
+    context 'running 状態で残り時間が 0 以下になっているとき' do
+      let(:purification_time) do
+        create(:purification_time,
+               status: :running,
+               remaining_time: 60,
+               total_time: 60,
+               started_at: 2.minutes.ago)
+      end
+
+      it 'idle 状態に戻ること (finish!)' do
+        purification_time.stop!
+        expect(purification_time.reload).to be_idle
+      end
+
+      it '各値がリセットされること' do
+        purification_time.stop!
+        purification_time.reload
+        aggregate_failures do
+          expect(purification_time.remaining_time).to eq 0
+          expect(purification_time.total_time).to eq 0
+          expect(purification_time.started_at).to be_nil
+          expect(purification_time.paused_at).to be_nil
+        end
+      end
+    end
+
+    context 'idle 状態のとき' do
+      let(:purification_time) { create(:purification_time) }
+
+      it '何も更新されないこと' do
+        expect { purification_time.stop! }.not_to change { purification_time.reload.updated_at }
+      end
+    end
+
+    context 'paused 状態のとき' do
+      let(:purification_time) { create(:purification_time, :paused) }
+
+      it '何も更新されないこと' do
+        expect { purification_time.stop! }.not_to change { purification_time.reload.updated_at }
+      end
+
+      it 'paused 状態のままであること' do
+        purification_time.stop!
+        expect(purification_time.reload).to be_paused
+      end
+    end
+  end
+
+  # =========================================================
+  # #reset!
+  # =========================================================
+  describe '#reset!' do
+    let(:purification_time) { create(:purification_time, :paused) }
+
+    it 'idle 状態に戻ること' do
+      purification_time.reset!
+      expect(purification_time.reload).to be_idle
+    end
+
+    it '各値が初期化されること' do
+      purification_time.reset!
+      purification_time.reload
+      aggregate_failures do
+        expect(purification_time.remaining_time).to eq 0
+        expect(purification_time.total_time).to eq 0
+        expect(purification_time.started_at).to be_nil
+        expect(purification_time.paused_at).to be_nil
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,8 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   # FactoryBotの設定
   config.include FactoryBot::Syntax::Methods
+  # freeze_time を利用
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # System Spec の設定
   config.before(:each, type: :system) do

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe 'ActivityRecords', type: :request do
       get pomodoro_timer_activity_records_path
       expect(response).to have_http_status(:ok)
     end
+
+    context 'task パラメータがあるとき' do
+      it 'レスポンスボディに task の内容が含まれること' do
+        get pomodoro_timer_activity_records_path(task: 'テストタスク')
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('テストタスク')
+        end
+      end
+    end
   end
 
   # =========================================================

--- a/spec/requests/purification_times_spec.rb
+++ b/spec/requests/purification_times_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe 'PurificationTimes', type: :request do
+  let(:user) { create(:user) }
+  let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+  before { sign_in user }
+
+  # =========================================================
+  # GET /purification_time
+  # =========================================================
+  describe 'GET /purification_time' do
+    context 'HTML リクエスト' do
+      it '200 を返すこと' do
+        get purification_time_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'JSON リクエスト' do
+      it 'running 状態を JSON で返すこと' do
+        get purification_time_path, headers: { 'Accept' => 'application/json' }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          json = JSON.parse(response.body)
+          expect(json).to have_key('running')
+          expect(json['running']).to be false
+        end
+      end
+
+      context 'running 状態のとき' do
+        let!(:purification_time) { create(:purification_time, :running, user: user) }
+
+        it 'running: true を返すこと' do
+          get purification_time_path, headers: { 'Accept' => 'application/json' }
+          json = JSON.parse(response.body)
+          expect(json['running']).to be true
+        end
+      end
+    end
+
+    context '未ログインのとき' do
+      before { sign_out user }
+
+      it 'ログインページへリダイレクトされること' do
+        get purification_time_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  # =========================================================
+  # PATCH /purification_time/start
+  # =========================================================
+  describe 'PATCH /purification_time/start' do
+    it '200 を返すこと' do
+      patch start_purification_time_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'start! が実行されて running 状態になること' do
+      patch start_purification_time_path
+      expect(purification_time.reload).to be_running
+    end
+  end
+
+  # =========================================================
+  # PATCH /purification_time/stop
+  # =========================================================
+  describe 'PATCH /purification_time/stop' do
+    let!(:purification_time) do
+      create(:purification_time,
+             user: user,
+             status: :running,
+             remaining_time: 600,
+             total_time: 600,
+             started_at: 1.minute.ago)
+    end
+
+    it '200 を返すこと' do
+      patch stop_purification_time_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'stop! が実行されて paused 状態に変わること' do
+      patch stop_purification_time_path
+      expect(purification_time.reload).to be_paused
+    end
+  end
+
+  # =========================================================
+  # PATCH /purification_time/reset
+  # =========================================================
+  describe 'PATCH /purification_time/reset' do
+    let!(:purification_time) { create(:purification_time, :paused, user: user) }
+
+    it '200 を返すこと' do
+      patch reset_purification_time_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'reset! が実行されて idle 状態に戻ること' do
+      patch reset_purification_time_path
+      expect(purification_time.reload).to be_idle
+    end
+  end
+end

--- a/spec/requests/users/users_spec.rb
+++ b/spec/requests/users/users_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe "Users", type: :request do
       end
     end
   end
+
+  describe "GET /users/sign_up" do
+    context "ログイン済み" do
+      it "rootにリダイレクトされる" do
+        sign_in user
+
+        get new_user_registration_path
+
+        expect(response).to redirect_to(root_path)
+
+        follow_redirect!
+        expect(response.body).to include(
+          I18n.t("devise.failure.already_authenticated")
+        )
+      end
+    end
+  end
 end

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -10,6 +10,33 @@ RSpec.describe 'ActivityRecords システムテスト', type: :system do
     sign_in user
   end
 
+  describe 'マイページからポモドーロタイマー画面への遷移' do
+    it '「やること」を入力してスタートすると入力内容が引き継がれること' do
+      visit mypage_path
+      fill_in 'やることを入力', with: 'マイページからのタスク'
+      click_on 'スタート'
+
+      aggregate_failures do
+        expect(page).to have_current_path(pomodoro_timer_activity_records_path, ignore_query: true)
+        expect(page).to have_content('マイページからのタスク')
+      end
+    end
+
+    it '「やること」未入力でスタートしてもポモドーロタイマー画面に遷移できること' do
+      visit mypage_path
+      # やることを入力せずにスタート
+      click_on 'スタート'
+
+      aggregate_failures do
+        expect(page).to have_current_path(pomodoro_timer_activity_records_path, ignore_query: true)
+        # タイマー画面の主要要素が表示される
+        expect(page).to have_content('25:00')
+        expect(page).to have_content('朝のランニング')
+        expect(page).to have_content('健康的な自分')
+      end
+    end
+  end
+
   # =========================================================
   # ポモドーロタイマー画面
   # =========================================================

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -12,10 +12,12 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード確認", with: "password123"
     click_button "アカウント作成"
 
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content(
-      I18n.t("devise.registrations.signed_up")
-    )
+    aggregate_failures do
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content(
+        I18n.t("devise.registrations.signed_up")
+      )
+    end
   end
 
   it "新規登録に失敗するとエラーメッセージが表示される" do
@@ -27,13 +29,15 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード確認", with: "password123"
     click_button "アカウント作成"
 
-    expect(page).to have_current_path(new_user_registration_path)
+    aggregate_failures do
+      expect(page).to have_current_path(new_user_registration_path)
 
-    # エラーメッセージ
-    expect(page).to have_content("メールアドレスを入力してください")
-    # 入力した値が保持されているか
-    expect(page).to have_field("名前", with: "山田太郎")
-    expect(page).to have_field("メールアドレス", with: "")
+      # エラーメッセージ
+      expect(page).to have_content("メールアドレスを入力してください")
+      # 入力した値が保持されているか
+      expect(page).to have_field("名前", with: "山田太郎")
+      expect(page).to have_field("メールアドレス", with: "")
+    end
   end
 
   it "ログインできる" do
@@ -43,10 +47,16 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード", with: "password123"
     click_button "ログイン"
 
-    expect(page).to have_current_path(root_path)
-    expect(page).to have_content(
-      I18n.t("devise.sessions.signed_in")
-    )
+    aggregate_failures do
+      expect(page).to have_current_path(root_path)
+      expect(page).to have_content(
+        I18n.t("devise.sessions.signed_in")
+      )
+      # ログインしたユーザーの情報が表示されている
+      expect(page).to have_content(user.name)
+      # ログアウトリンクが見える(ログイン済みであることの証拠)
+      expect(page).to have_link("ログアウト")
+    end
   end
 
   it "ログアウトできる" do
@@ -60,19 +70,23 @@ RSpec.describe "Authentications", type: :system do
     # ログアウト操作
     click_link "ログアウト"
 
-    expect(page).to have_current_path(new_user_session_path)
-    expect(page).to have_content(
-      I18n.t("devise.sessions.signed_out")
-    )
+    aggregate_failures do
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content(
+        I18n.t("devise.sessions.signed_out")
+      )
+    end
   end
 
   it "未ログインでマイページにアクセスするとログイン画面に飛ばされる" do
     visit mypage_path
 
-    expect(page).to have_current_path(new_user_session_path)
-    expect(page).to have_content(
-      I18n.t("devise.failure.unauthenticated")
-    )
+    aggregate_failures do
+      expect(page).to have_current_path(new_user_session_path)
+      expect(page).to have_content(
+        I18n.t("devise.failure.unauthenticated")
+      )
+    end
   end
 
 end

--- a/spec/system/purification_times_spec.rb
+++ b/spec/system/purification_times_spec.rb
@@ -1,0 +1,257 @@
+require 'rails_helper'
+
+RSpec.describe 'PurificationTimes', type: :system do
+  let(:user) { create(:user) }
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time) { create(:dark_time, user: user) }
+
+  before { sign_in user }
+
+  # =========================================================
+  # マイページ側の浄化タイマー UI
+  # =========================================================
+  describe 'マイページの浄化タイマー表示' do
+    context 'PurificationTime が存在しないとき(ActivityRecord 未登録)' do
+      it '浄化タイマー UI が表示されないこと' do
+        visit mypage_path
+        expect(page).not_to have_content('浄化タイマー')
+      end
+    end
+
+    context 'PurificationTime が存在するとき(ActivityRecord 登録済み)' do
+      context 'remaining_time が 0 のとき (finished)' do
+        let!(:purification_time) { create(:purification_time, user: user, remaining_time: 0) }
+
+        it '「メッセージ」リンクが表示されること' do
+          visit mypage_path
+          aggregate_failures do
+            expect(page).to have_content('浄化タイマー')
+            expect(page).to have_link('メッセージ', href: purification_time_path)
+            # スタート・リセットは表示されない
+            expect(page).not_to have_link('スタート', href: purification_time_path)
+            expect(page).not_to have_button('リセット')
+          end
+        end
+      end
+
+      context 'remaining_time が付与されている idle のとき' do
+        let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+        it 'スタートリンクとリセットボタンが表示されること' do
+          visit mypage_path
+          aggregate_failures do
+            expect(page).to have_content('10 分 00 秒')
+            expect(page).to have_link('スタート', href: purification_time_path)
+            expect(page).to have_button('リセット')
+          end
+        end
+      end
+
+      context 'running のとき' do
+        let!(:purification_time) { create(:purification_time, :running, user: user) }
+
+        it '「実行中」リンクが表示されること' do
+          visit mypage_path
+          aggregate_failures do
+            expect(page).to have_link('実行中', href: purification_time_path)
+            # スタートやメッセージは表示されない
+            expect(page).not_to have_link('スタート', href: purification_time_path)
+            expect(page).not_to have_link('メッセージ', href: purification_time_path)
+          end
+        end
+      end
+
+      context 'paused のとき' do
+        let!(:purification_time) { create(:purification_time, :paused, user: user) }
+
+        it 'スタートリンクとリセットボタンが表示されること' do
+          visit mypage_path
+          aggregate_failures do
+            expect(page).to have_link('スタート', href: purification_time_path)
+            expect(page).to have_button('リセット')
+          end
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # 浄化タイマー詳細ページ
+  # =========================================================
+  describe '浄化タイマー詳細ページ' do
+    context 'remaining_time が 0 のとき (finished)' do
+      let!(:purification_time) { create(:purification_time, user: user, remaining_time: 0) }
+
+      it '完了メッセージと画像が表示されること' do
+        visit purification_time_path
+
+        aggregate_failures do
+          expect(page).to have_content('浄化が完了しました')
+          expect(page).to have_content('また、活動時間を計測してから来てね')
+          expect(page).to have_content('30分毎に10分よ')
+          expect(page).to have_content('忘れないでね')
+          expect(page).to have_css("img[src*='timer']")
+          expect(page).to have_link('マイページに戻る', href: mypage_path)
+        end
+      end
+
+      it '「マイページに戻る」を押すとマイページへ遷移すること' do
+        visit purification_time_path
+        click_on 'マイページに戻る'
+        expect(page).to have_current_path(mypage_path)
+      end
+    end
+
+    context 'idle で残り時間があるとき' do
+      let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+      it 'スタートとキャンセルボタンが表示されること' do
+        visit purification_time_path
+
+        aggregate_failures do
+          # display ターゲットの存在を確認(中身は JS が更新)
+          expect(page).to have_css("[data-purification-timer-target='display']")
+          expect(page).to have_css("img[src*='timer']")
+          expect(page).to have_button('スタート')
+          expect(page).to have_link('キャンセル', href: mypage_path)
+        end
+      end
+
+      it 'キャンセルを押すとマイページへ遷移すること' do
+        visit purification_time_path
+        click_on 'キャンセル'
+        expect(page).to have_current_path(mypage_path)
+      end
+    end
+
+    context 'running のとき', js: true do
+      let!(:purification_time) { create(:purification_time, :running, user: user) }
+
+      it '「終了する」ボタンが表示されること' do
+        visit purification_time_path
+        expect(page).to have_button('終了する')
+      end
+
+      it '「終了する」を押すとマイページへ戻ること' do
+        visit purification_time_path
+        click_on '終了する'
+        expect(page).to have_current_path(mypage_path)
+      end
+    end
+
+    context 'paused のとき' do
+      let!(:purification_time) { create(:purification_time, :paused, user: user) }
+
+      it 'スタートとキャンセルボタンが表示され、他の状態の要素は出ないこと' do
+        visit purification_time_path
+
+        aggregate_failures do
+          # 表示されるべき要素
+          expect(page).to have_button('スタート')
+          expect(page).to have_link('キャンセル', href: mypage_path)
+
+          # 他の状態の要素は出ない
+          expect(page).not_to have_button('終了する')         # running 用
+          expect(page).not_to have_content('浄化が完了しました')  # finished 用
+        end
+      end
+    end
+  end
+
+  # タイマーの動作確認は手動テストで実施
+
+  # =========================================================
+  # マイページからのフロー
+  # =========================================================
+  describe 'マイページから浄化タイマーを開始するフロー', js: true do
+    let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+    it 'スタートリンクからスタートして実行中状態になること' do
+      visit mypage_path
+
+      # マイページの「スタート」リンクで詳細ページへ
+      within('[data-controller="purification-timer"]') do
+        click_on 'スタート'
+      end
+
+      # 詳細ページの「スタート」ボタンを押す
+      click_on 'スタート'
+
+      # location.reload() 後の「終了する」ボタンが表示されるのを確認
+      expect(page).to have_button('終了する')
+      expect(purification_time.reload).to be_running
+    end
+  end
+
+  # =========================================================
+  # リセット機能
+  # =========================================================
+  describe 'マイページのリセットボタン' do
+    context 'idle 状態のとき', js: true do
+      let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+      it 'confirm で OK するとリセットされること' do
+        visit mypage_path
+
+        accept_confirm('本当にタイマーをリセットしてもよろしいでしょうか？') do
+          click_button 'リセット'
+        end
+
+        # reload 後、remaining_time が 0 になっている
+        expect(page).to have_content('0 分 00 秒')
+        expect(purification_time.reload.remaining_time).to eq 0
+      end
+    end
+
+    context 'idle 状態のときに confirm でキャンセルした場合', js: true do
+      let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+      it 'リセットされないこと' do
+        visit mypage_path
+
+        dismiss_confirm('本当にタイマーをリセットしてもよろしいでしょうか？') do
+          click_button 'リセット'
+        end
+
+        # リセットされていないことを確認
+        expect(purification_time.reload.remaining_time).to eq 600
+      end
+    end
+
+    context 'running 状態のとき' do
+      let!(:purification_time) { create(:purification_time, :running, user: user) }
+
+      it 'マイページではリセットボタンが表示されないこと（実行中は「実行中」リンクのみ）' do
+        visit mypage_path
+        expect(page).not_to have_button('リセット')
+      end
+    end
+  end
+
+  # =========================================================
+  # リセットボタン押下時の実行中チェック
+  # =========================================================
+  describe 'リセットボタン押下時の実行中チェック', js: true do
+    context 'マイページ表示中にタイマーが running 状態になったとき' do
+      let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+      it '「タイマー実行中です」アラートが表示されること' do
+        visit mypage_path
+
+        # 別タブ等でスタートされたシナリオを再現
+        purification_time.update!(
+          status: :running,
+          started_at: Time.current,
+          total_time: 600
+        )
+
+        accept_alert('タイマー実行中です') do
+          click_button 'リセット'
+        end
+
+        # リセットが実行されていないことを確認
+        expect(purification_time.reload).to be_running
+      end
+    end
+  end
+end

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'StaticPages', type: :system do
+  # =========================================================
+  # ホーム画面
+  # =========================================================
+  describe 'ホーム画面' do
+    context '未ログインのとき' do
+      it 'ホーム画面が表示され、主要な動線リンクが見えること' do
+        visit root_path
+
+        aggregate_failures do
+          expect(page).to have_content('Get The Time')
+          expect(page).to have_link('はじめる', href: new_user_registration_path)
+          expect(page).to have_link('ログイン', href: new_user_session_path)
+        end
+      end
+    end
+
+    context 'ログイン済みのとき' do
+      let(:user) { create(:user) }
+      before { sign_in user }
+
+      it 'root にアクセスするとマイページの内容が表示されること' do
+        visit root_path
+
+        aggregate_failures do
+          expect(page).to have_content(user.name)
+          expect(page).to have_link('使い方', href: how_to_use_path)
+          expect(page).to have_link('ログアウト')
+        end
+      end
+    end
+  end
+
+  # =========================================================
+  # 使い方ページ
+  # =========================================================
+  describe '使い方ページ' do
+    context '未ログインのとき' do
+      it 'ログインページへリダイレクトされること' do
+        visit how_to_use_path
+        expect(page).to have_current_path(new_user_session_path)
+      end
+    end
+
+    context 'ログイン済みのとき' do
+      let(:user) { create(:user) }
+      before { sign_in user }
+
+      it '表示され、マイページへ戻るリンクが見えること' do
+        visit how_to_use_path
+
+        aggregate_failures do
+          expect(page).to have_current_path(how_to_use_path)
+          expect(page).to have_content('概要')
+          expect(page).to have_link('マイページに戻る', href: mypage_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
浄化タイマーのテストコードを追加を行います。

- [x] PurificaitonTimeのモデルスペックのテストコードを作成
- [x] 浄化タイマーのタイマー機能のテストコードを作成
- [x] 浄化タイマーのリセット機能のテストコードを作成

### 補足事項
PurificationTimeについて
- モデルスペックで freeze_time を用いるために、rails_helper.rbで設定を行った
- fetch関数において、csrfToken の設定を行った
- タイマーの動作は手動テストで確認することにする
- ActivityRecordモデルにおいて、grant_purification_timeメソッドにおいて、PurificationTimeの有無に関するテストケースを追加
- 浄化タイマーの時間付与のテストコードを作成については、前回（#160）で作成済み
 
PurificationTime以外について
- ヘルパーメソッドのテストを追加
- ActivityRecordのモデルスペックについて：変数名recordをactivity_recordに変更
- ホーム画面及び使い方の画面遷移に関するテストコードを追加
- マイページからポモドーロタイマー画面へ遷移する際にやることを入力したテストケースを追加
- ログイン後にuser/sign_upにアクセスした際のテストケースをrequests/users_spec.rb に追記
- aggregate_failuresの追加及びログイン後のマイページの表示内容を認証のシステムスペックに追加