### PR TITLE
feat: 光の時間の活動記録にお気に入り機能を追加

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -1,6 +1,6 @@
 class ActivityRecordsController < ApplicationController
   before_action :set_light_and_dark_times, only: %i[new create]
-  before_action :set_activity_record, only: %i[show edit update destroy]
+  before_action :set_activity_record, only: %i[show edit update destroy favorite]
 
   def index
     @q = current_user.activity_records.ransack(params[:q])
@@ -50,6 +50,15 @@ class ActivityRecordsController < ApplicationController
   def destroy
     @activity_record.destroy!
     redirect_to activity_records_path, notice: t("defaults.flash_message.deleted", item: ActivityRecord.model_name.human), status: :see_other
+  end
+
+  def favorite
+    @activity_record.update!(favorited: !@activity_record.favorited)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to activity_records_path }
+    end
   end
 
   def pomodoro_timer

--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -53,7 +53,7 @@ class ActivityRecord < ApplicationRecord
 
   # 検索可能カラムの登録
   def self.ransackable_attributes(auth_object = nil)
-    [ "comment" ]  # 検索可能なカラム
+    [ "comment", "favorited" ]  # 検索可能なカラム
   end
 
   # 検索可能な関連付けをホワイトリスト化

--- a/app/views/activity_records/_activity_record.html.erb
+++ b/app/views/activity_records/_activity_record.html.erb
@@ -1,22 +1,40 @@
-<div class="bg-amber-500 hover:bg-amber-60 rounded-lg px-4 py-3 shadow transition duration-200">
+<%= turbo_frame_tag dom_id(activity_record), class: "block" do %>
+  <div class="bg-amber-500 hover:bg-amber-60 rounded-lg px-4 py-3 shadow transition duration-200 flex items-start gap-3">
 
-  <%= link_to activity_record_path(activity_record), class: "block flex flex-wrap gap-6 text-lg" do %>
+    <!-- お気に入りトグル -->
+    <%= button_to favorite_activity_record_path(activity_record),
+                  method: :patch,
+                  form: { data: { turbo_frame: dom_id(activity_record) } },
+                  class: "shrink-0 text-2xl leading-none focus:outline-none",
+                  title: activity_record.favorited? ? "お気に入りを解除" : "お気に入りに追加",
+                  aria: { label: activity_record.favorited? ? "お気に入りを解除" : "お気に入りに追加" } do %>
+      <% if activity_record.favorited? %>
+        <span class="text-yellow-300">★</span>
+      <% else %>
+        <span class="text-gray-300">☆</span>
+      <% end %>
+    <% end %>
 
-    <!-- 日時 -->
-    <span>
-      <%= format_datetime(activity_record.started_at) %>
-    </span>
+    <%= link_to activity_record_path(activity_record),
+                class: "flex-1 flex flex-wrap gap-6 text-lg",
+                data: { turbo_frame: "_top" } do %>
 
-    <!-- 光の時間の活動内容 -->
-    <span>
-      <%= activity_record.light_time&.action %>
-    </span>
+      <!-- 日時 -->
+      <span>
+        <%= format_datetime(activity_record.started_at) %>
+      </span>
 
-    <!-- コメント -->
-    <span class="text-gray-800">
-      <%= activity_record.comment.presence || "コメント記入なし" %>
-    </span>
+      <!-- 光の時間の活動内容 -->
+      <span>
+        <%= activity_record.light_time&.action %>
+      </span>
 
-  <% end %>
+      <!-- コメント -->
+      <span class="text-gray-800">
+        <%= activity_record.comment.presence || "コメント記入なし" %>
+      </span>
 
-</div>
+    <% end %>
+
+  </div>
+<% end %>

--- a/app/views/activity_records/_search_form.html.erb
+++ b/app/views/activity_records/_search_form.html.erb
@@ -1,4 +1,18 @@
+<% favorited_active = q.favorited_eq.to_s == "true" %>
+<% keyword = q.comment_or_light_time_action_cont %>
+
+<!-- お気に入り絞り込みタブ -->
+<div class="flex gap-2 mb-3">
+  <%= link_to "すべて",
+              url_for(q: { comment_or_light_time_action_cont: keyword }),
+              class: "px-4 py-2 rounded-t-lg font-bold transition duration-200 #{favorited_active ? 'bg-gray-200 text-gray-600 hover:bg-gray-300' : 'bg-blue-500 text-white/90'}" %>
+  <%= link_to "★ お気に入り",
+              url_for(q: { comment_or_light_time_action_cont: keyword, favorited_eq: true }),
+              class: "px-4 py-2 rounded-t-lg font-bold transition duration-200 #{favorited_active ? 'bg-blue-500 text-white/90' : 'bg-gray-200 text-gray-600 hover:bg-gray-300'}" %>
+</div>
+
 <%= search_form_for q, url: url do |f| %>
+  <%= f.hidden_field :favorited_eq, value: favorited_active ? "true" : "" %>
   <div class="flex gap-3 mb-10">
     <%= f.search_field :comment_or_light_time_action_cont, placeholder: "コメント or 活動内容で検索", class: "flex-1 px-4 py-2 bg-gray-200 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
     <%= f.submit '検索', class: "px-6 py-2 bg-blue-500 text-white/90 font-bold rounded-lg hover:bg-blue-600 transition duration-200" %>

--- a/app/views/activity_records/favorite.turbo_stream.erb
+++ b/app/views/activity_records/favorite.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace dom_id(@activity_record), partial: "activity_records/activity_record", locals: { activity_record: @activity_record } %>

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -31,8 +31,10 @@
   <% else %>
     <div class="flex items-center justify-center min-h-[60vh]">
       <p class="text-lg">
-        <% if params[:q].present? %>
+        <% if params.dig(:q, :comment_or_light_time_action_cont).present? %>
           検索結果が見つかりませんでした
+        <% elsif params.dig(:q, :favorited_eq).to_s == "true" %>
+          お気に入りの活動記録がありません。★をクリックして追加できます
         <% else %>
           光の時間の活動記録が登録されていません
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
     collection do
       get :pomodoro_timer    # タイマーページ
     end
+    member do
+      patch :favorite        # お気に入りトグル
+    end
   end
 
   # 浄化タイマー

--- a/db/migrate/20260527141310_add_favorited_to_activity_records.rb
+++ b/db/migrate/20260527141310_add_favorited_to_activity_records.rb
@@ -1,0 +1,5 @@
+class AddFavoritedToActivityRecords < ActiveRecord::Migration[8.1]
+  def change
+    add_column :activity_records, :favorited, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_141309) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_141310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_141309) do
     t.decimal "desired_self_percentage", precision: 5, scale: 2
     t.datetime "ended_at"
     t.integer "fatigue"
+    t.boolean "favorited", default: false, null: false
     t.integer "focus"
     t.integer "idle_duration"
     t.bigint "light_time_id", null: false

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -287,8 +287,8 @@ RSpec.describe ActivityRecord, type: :model do
   # ransack の検索可能カラム
   # =========================================================
   describe "ransack の検索可能カラム" do
-    it "検索可能なカラムが comment のみであること" do
-      expect(described_class.ransackable_attributes).to eq [ "comment" ]
+    it "検索可能なカラムが comment と favorited であること" do
+      expect(described_class.ransackable_attributes).to eq [ "comment", "favorited" ]
     end
 
     it "検索可能な関連付けが light_time のみであること" do

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -308,6 +308,62 @@ RSpec.describe "ActivityRecords", type: :request do
   end
 
   # =========================================================
+  # PATCH /activity_records/:id/favorite
+  # =========================================================
+  describe "PATCH /activity_records/:id/favorite" do
+    let!(:activity_record) do
+      create(:activity_record, user: user, light_time: light_time, favorited: false)
+    end
+
+    context "favorited が false のとき" do
+      it "true にトグルされること" do
+        expect {
+          patch favorite_activity_record_path(activity_record)
+        }.to change { activity_record.reload.favorited }.from(false).to(true)
+      end
+
+      it "turbo_stream リクエストで 200 を返すこと" do
+        patch favorite_activity_record_path(activity_record),
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        end
+      end
+
+      it "html リクエストで一覧ページへリダイレクトすること" do
+        patch favorite_activity_record_path(activity_record)
+        expect(response).to redirect_to(activity_records_path)
+      end
+    end
+
+    context "favorited が true のとき" do
+      before { activity_record.update!(favorited: true) }
+
+      it "false にトグルされること" do
+        expect {
+          patch favorite_activity_record_path(activity_record)
+        }.to change { activity_record.reload.favorited }.from(true).to(false)
+      end
+    end
+
+    context "他ユーザーのレコードに対して操作すると" do
+      let!(:other_activity_record) do
+        create(:activity_record, user: other_user, light_time: other_light_time, favorited: false)
+      end
+
+      it "更新できず 404 を返すこと" do
+        aggregate_failures do
+          expect {
+            patch favorite_activity_record_path(other_activity_record)
+          }.not_to change { other_activity_record.reload.favorited }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
+
+  # =========================================================
   # DELETE /activity_records/:id (destroy)
   # =========================================================
   describe "DELETE /activity_records/:id" do

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -392,6 +392,37 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
       end
     end
 
+    context "お気に入りトグル" do
+      let!(:activity_record) do
+        create(:activity_record, user: user, light_time: light_time, comment: "お気に入り対象")
+      end
+
+      it "☆ をクリックすると ★ に切り替わり、レコードが favorited になること" do
+        visit activity_records_path
+
+        within("##{ActionView::RecordIdentifier.dom_id(activity_record)}") do
+          expect(page).to have_button("お気に入りに追加")
+          click_on "お気に入りに追加"
+          expect(page).to have_button("お気に入りを解除")
+        end
+
+        expect(activity_record.reload.favorited).to be true
+      end
+
+      it "★ をクリックすると ☆ に戻り、favorited が false になること" do
+        activity_record.update!(favorited: true)
+        visit activity_records_path
+
+        within("##{ActionView::RecordIdentifier.dom_id(activity_record)}") do
+          expect(page).to have_button("お気に入りを解除")
+          click_on "お気に入りを解除"
+          expect(page).to have_button("お気に入りに追加")
+        end
+
+        expect(activity_record.reload.favorited).to be false
+      end
+    end
+
     context "検索フォームを使ったとき" do
       before do
         create(:activity_record, user: user, light_time: light_time, comment: "検索ヒット")
@@ -411,6 +442,50 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
         fill_in "コメント or 活動内容で検索", with: "存在しないキーワード"
         click_on "検索"
         expect(page).to have_content("検索結果が見つかりませんでした")
+      end
+    end
+
+    context "お気に入りで絞り込みするとき" do
+      before do
+        create(:activity_record, user: user, light_time: light_time, comment: "お気に入り対象", favorited: true)
+        create(:activity_record, user: user, light_time: light_time, comment: "通常レコード", favorited: false)
+      end
+
+      it "「★ お気に入り」タブをクリックするとお気に入りのみ表示されること" do
+        visit activity_records_path
+        click_on "★ お気に入り"
+
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).not_to have_content("通常レコード")
+        end
+      end
+
+      it "「すべて」タブをクリックすると全件表示されること" do
+        visit activity_records_path(q: { favorited_eq: true })
+
+        # まずお気に入りのみ表示されていることを確認
+        expect(page).to have_content("お気に入り対象")
+        expect(page).not_to have_content("通常レコード")
+
+        click_on "すべて"
+
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).to have_content("通常レコード")
+        end
+      end
+    end
+
+    context "お気に入りタブでお気に入りが1件もないとき" do
+      before do
+        create(:activity_record, user: user, light_time: light_time, favorited: false)
+      end
+
+      it "お気に入り未登録のメッセージが表示されること" do
+        visit activity_records_path
+        click_on "★ お気に入り"
+        expect(page).to have_content("お気に入りの活動記録がありません。★をクリックして追加できます")
       end
     end
   end


### PR DESCRIPTION
## Summary
- 一覧画面で ★/☆ アイコンによりお気に入りをトグル可能（Turbo Stream で即時更新）
- タブ形式（[すべて] / [★ お気に入り]）でお気に入り絞り込みに対応。検索キーワードはタブ切替時も保持
- お気に入り 0 件のタブ表示時には「お気に入りの活動記録がありません。★をクリックして追加できます」と専用メッセージを表示

## 主な変更点
- `activity_records.favorited` カラム（boolean, default: false, null: false）を追加
- `PATCH /activity_records/:id/favorite` ルートとコントローラアクションを追加
- `ActivityRecord.ransackable_attributes` に `"favorited"` を追加して絞り込み対応
- お気に入り対象は自分の活動記録のみのため、中間テーブルではなく boolean カラムで実装

## Test plan
- [x] 一覧画面で ☆ をクリックすると ★ に切り替わり、フルリロードなしで更新されること
- [x] ★ をクリックすると ☆ に戻ること
- [x] [★ お気に入り] タブでお気に入り済みのみ表示されること
- [x] [すべて] タブで全件表示に戻ること
- [x] 検索キーワード入力後にタブを切り替えてもキーワードが保持されること
- [x] お気に入り 0 件のときに専用メッセージが表示されること
- [x] 詳細ページへのリンクが Turbo フレーム内でも正常に遷移すること
- [x] RSpec（model / request / system）全てパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)