### PR TITLE
feat: 活動記録の評価集計メソッドを追加

### DIFF
--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -11,8 +11,15 @@ class ActivityRecord < ApplicationRecord
 
   validates :satisfaction, :progress, :quality, :focus, :fatigue, inclusion: { in: 1..5 }
 
+  # レーダーチャート対象の5段階評価カラム（疲労感は逆指標のため別集計）
+  RADAR_FIELDS = %i[satisfaction progress quality focus].freeze
+
   scope :today, -> {
     where(created_at: Time.current.all_day)
+  }
+
+  scope :within_last_days, ->(days) {
+    where(created_at: days.days.ago.beginning_of_day..)
   }
 
   def self.total_light_time_today(user)
@@ -20,6 +27,45 @@ class ActivityRecord < ApplicationRecord
       .today
       .sum(:total_duration)
       .to_i
+  end
+
+  # レーダーチャート用: 直近N日の5段階評価4項目の平均
+  def self.evaluation_averages(user, days: 30)
+    records = user.activity_records.within_last_days(days)
+    RADAR_FIELDS.index_with { |field| records.average(field)&.to_f }
+  end
+
+  # 直近N日の疲労感の平均（逆指標のためレーダーから分離）
+  def self.fatigue_average(user, days: 30)
+    user.activity_records.within_last_days(days).average(:fatigue)&.to_f
+  end
+
+  # 直近N日の本来の自分の平均（全レコード平均）
+  def self.desired_self_percentage_average(user, days: 30)
+    user.activity_records.within_last_days(days).average(:desired_self_percentage)&.to_f
+  end
+
+  # 時系列グラフ用: 直近N日の日次集計（JST基準）
+  # light_time_minutes は SUM(total_duration) を分単位に丸めた Integer
+  # 該当レコードがない日は配列に含まれない
+  def self.daily_series(user, days: 30)
+    bucket = Arel.sql("DATE((created_at AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Tokyo')")
+    user.activity_records
+        .within_last_days(days)
+        .group(bucket)
+        .order(bucket)
+        .pluck(
+          bucket,
+          Arel.sql("SUM(total_duration)"),
+          Arel.sql("AVG(desired_self_percentage)")
+        )
+        .map do |date, total_duration_sum, desired_self_avg|
+          {
+            date: date,
+            light_time_minutes: (total_duration_sum.to_i / 60),
+            desired_self_percentage: desired_self_avg&.to_f
+          }
+        end
   end
 
   # 付与分数の重み付きテーブル（合計 100）

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -284,6 +284,225 @@ RSpec.describe ActivityRecord, type: :model do
   end
 
   # =========================================================
+  # .evaluation_averages
+  # =========================================================
+  describe ".evaluation_averages" do
+    subject(:averages) { described_class.evaluation_averages(user, days: 30) }
+
+    context "記録が一件もないとき" do
+      it "4項目すべてのキーが nil で返ること" do
+        expect(averages).to eq(satisfaction: nil, progress: nil, quality: nil, focus: nil)
+      end
+
+      it "疲労感のキーは含まれないこと" do
+        expect(averages).not_to have_key(:fatigue)
+      end
+    end
+
+    context "直近30日以内の記録が複数あるとき" do
+      before do
+        create(:activity_record, :high_rating, user: user, light_time: light_time)
+        create(:activity_record, :low_rating,  user: user, light_time: light_time)
+      end
+
+      it "4項目それぞれの平均値が返ること" do
+        # high(5) と low(1) の平均はすべて 3.0
+        expect(averages).to eq(satisfaction: 3.0, progress: 3.0, quality: 3.0, focus: 3.0)
+      end
+    end
+
+    context "30日より古い記録は集計に含めないこと" do
+      before do
+        create(:activity_record, :high_rating, user: user, light_time: light_time)
+        old_record = build(:activity_record, :low_rating, user: user, light_time: light_time)
+        old_record.save!
+        old_record.update_column(:created_at, 31.days.ago)
+      end
+
+      it "期間内（high_rating）のみが平均値に反映されること" do
+        expect(averages).to eq(satisfaction: 5.0, progress: 5.0, quality: 5.0, focus: 5.0)
+      end
+    end
+
+    context "別ユーザーの記録は集計に含めないこと" do
+      let(:other_user)  { create(:user) }
+      let(:other_light) { create(:light_time, :current, user: other_user) }
+
+      before do
+        create(:activity_record, :high_rating, user: other_user, light_time: other_light)
+      end
+
+      it "対象ユーザーの記録がなければ nil になること" do
+        expect(averages).to eq(satisfaction: nil, progress: nil, quality: nil, focus: nil)
+      end
+    end
+  end
+
+  # =========================================================
+  # .fatigue_average
+  # =========================================================
+  describe ".fatigue_average" do
+    subject { described_class.fatigue_average(user, days: 30) }
+
+    context "記録が一件もないとき" do
+      it { is_expected.to be_nil }
+    end
+
+    context "直近30日以内の記録が複数あるとき" do
+      before do
+        create(:activity_record, user: user, light_time: light_time, fatigue: 2)
+        create(:activity_record, user: user, light_time: light_time, fatigue: 4)
+      end
+
+      it "平均値を返すこと" do
+        is_expected.to eq 3.0
+      end
+    end
+
+    context "30日より古い記録は集計に含めないこと" do
+      before do
+        create(:activity_record, user: user, light_time: light_time, fatigue: 2)
+        old_record = build(:activity_record, user: user, light_time: light_time, fatigue: 5)
+        old_record.save!
+        old_record.update_column(:created_at, 31.days.ago)
+      end
+
+      it "期間内の値のみが平均に反映されること" do
+        is_expected.to eq 2.0
+      end
+    end
+  end
+
+  # =========================================================
+  # .desired_self_percentage_average
+  # =========================================================
+  describe ".desired_self_percentage_average" do
+    subject { described_class.desired_self_percentage_average(user, days: 30) }
+
+    context "記録が一件もないとき" do
+      it { is_expected.to be_nil }
+    end
+
+    context "直近30日以内の記録が複数あるとき" do
+      before do
+        # (100 - 20) / 100.0 = 0.8
+        create(:activity_record, user: user, light_time: light_time,
+                                 total_duration: 100, idle_duration: 20)
+        # (100 - 40) / 100.0 = 0.6
+        create(:activity_record, user: user, light_time: light_time,
+                                 total_duration: 100, idle_duration: 40)
+      end
+
+      it "全レコードの平均値を返すこと" do
+        is_expected.to be_within(0.001).of(0.7)
+      end
+    end
+
+    context "30日より古い記録は集計に含めないこと" do
+      before do
+        create(:activity_record, user: user, light_time: light_time,
+                                 total_duration: 100, idle_duration: 20)
+        old_record = build(:activity_record, user: user, light_time: light_time,
+                                             total_duration: 100, idle_duration: 80)
+        old_record.save!
+        old_record.update_column(:created_at, 31.days.ago)
+      end
+
+      it "期間内の値のみが平均に反映されること" do
+        is_expected.to be_within(0.001).of(0.8)
+      end
+    end
+  end
+
+  # =========================================================
+  # .daily_series
+  # =========================================================
+  describe ".daily_series" do
+    subject(:series) { described_class.daily_series(user, days: 30) }
+
+    context "記録が一件もないとき" do
+      it { is_expected.to eq [] }
+    end
+
+    context "同日に複数レコードがあるとき" do
+      around { |example| travel_to(Time.zone.local(2026, 5, 28, 12, 0, 0)) { example.run } }
+
+      before do
+        create(:activity_record, user: user, light_time: light_time,
+                                 total_duration: 60, idle_duration: 0)
+        create(:activity_record, user: user, light_time: light_time,
+                                 total_duration: 120, idle_duration: 60)
+      end
+
+      it "同日の合計時間が分単位で合算されること" do
+        # SUM(60 + 120) / 60 = 3 分
+        expect(series.size).to eq 1
+        expect(series.first[:light_time_minutes]).to eq 3
+      end
+
+      it "同日の本来の自分が平均化されること" do
+        # AVG(1.0, 0.5) = 0.75
+        expect(series.first[:desired_self_percentage]).to be_within(0.001).of(0.75)
+      end
+
+      it "日付が JST の今日になること" do
+        expect(series.first[:date]).to eq Date.new(2026, 5, 28)
+      end
+    end
+
+    context "JST で日跨ぎする UTC レコード（JST 0:30 など）があるとき" do
+      around { |example| travel_to(Time.zone.local(2026, 5, 28, 12, 0, 0)) { example.run } }
+
+      before do
+        # JST 2026-05-28 0:30 = UTC 2026-05-27 15:30
+        record = create(:activity_record, user: user, light_time: light_time,
+                                          total_duration: 60, idle_duration: 0)
+        record.update_column(:created_at, Time.zone.local(2026, 5, 28, 0, 30, 0))
+      end
+
+      it "JST の日付（5/28）でグルーピングされること" do
+        expect(series.first[:date]).to eq Date.new(2026, 5, 28)
+      end
+    end
+
+    context "複数日にレコードがあるとき" do
+      around { |example| travel_to(Time.zone.local(2026, 5, 28, 12, 0, 0)) { example.run } }
+
+      before do
+        r1 = create(:activity_record, user: user, light_time: light_time, total_duration: 60)
+        r1.update_column(:created_at, Time.zone.local(2026, 5, 26, 10, 0, 0))
+        r2 = create(:activity_record, user: user, light_time: light_time, total_duration: 120)
+        r2.update_column(:created_at, Time.zone.local(2026, 5, 27, 10, 0, 0))
+      end
+
+      it "日付昇順で返ること" do
+        expect(series.map { |row| row[:date] }).to eq [ Date.new(2026, 5, 26), Date.new(2026, 5, 27) ]
+      end
+    end
+
+    context "30日より古い記録は集計に含めないこと" do
+      before do
+        old_record = build(:activity_record, user: user, light_time: light_time, total_duration: 60)
+        old_record.save!
+        old_record.update_column(:created_at, 31.days.ago)
+      end
+
+      it { is_expected.to eq [] }
+    end
+
+    context "別ユーザーの記録は集計に含めないこと" do
+      let(:other_user)  { create(:user) }
+      let(:other_light) { create(:light_time, :current, user: other_user) }
+
+      before do
+        create(:activity_record, user: other_user, light_time: other_light, total_duration: 60)
+      end
+
+      it { is_expected.to eq [] }
+    end
+  end
+
+  # =========================================================
   # ransack の検索可能カラム
   # =========================================================
   describe "ransack の検索可能カラム" do

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード", with: "password123"
     click_button "ログイン"
 
-    # ログアウト操作
+    # ログイン後のリダイレクト完了を待ってからログアウト操作
+    expect(page).to have_link("ログアウト")
     click_link "ログアウト"
 
     aggregate_failures do


### PR DESCRIPTION
## Summary
- レーダーチャート用に、直近30日の5段階評価4項目（満足度・進行度・作業の質・集中度）の平均を返す `ActivityRecord.evaluation_averages` を追加
- 疲労感は逆指標のためレーダーから分離し、単独平均を返す `ActivityRecord.fatigue_average` を追加
- 「本来の自分」の全レコード平均を返す `ActivityRecord.desired_self_percentage_average` を追加
- 時系列グラフ用に、日次集計（JST基準・光の時間の合計分数＋本来の自分の日次平均）を返す `ActivityRecord.daily_series` を追加
- 補助として `within_last_days` scope と `RADAR_FIELDS` 定数を追加
- 上記とは別件で、ログアウトSystem Spec（`spec/system/authentications_spec.rb`）がCI上で稀に失敗していたため、`expect(page).to have_link("ログアウト")` の明示的待機を追加して flaky を解消

## 設計メモ
- DBカラムには保存せず、都度SQL集計（AVG/SUM）で算出する方針。活動記録の更新・削除に追随でき、副作用管理が増えない。
- JST基準の日付グルーピングは PostgreSQL の `AT TIME ZONE` で実装。`created_at` が `timestamp without time zone`（UTC格納）のため、`(created_at AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Tokyo'` で正しく丸める。
- 該当レコードがない日は `daily_series` の配列に含まれない（表示側で30日枠の欠損埋めを行う想定）。
- `light_time_minutes` というキー名で `LightTime` モデルとの対応を明示。

## Test plan
- [x] `bundle exec rspec spec/models/activity_record_spec.rb` が全件パス（92 examples / 0 failures）
- [x] `bundle exec rspec spec/system/authentications_spec.rb` が全件パス（5 examples / 0 failures）
- [x] CI 全件パス
- [x] `bin/rubocop` で指摘なし
- [ ] 後続PRで、本ロジックを使ったレーダーチャート / 時系列グラフのUI実装を行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)