### PR TITLE
feat: マイステータスページに直近30日の時系列グラフを追加

### DIFF
--- a/app/controllers/mystatuses_controller.rb
+++ b/app/controllers/mystatuses_controller.rb
@@ -1,0 +1,27 @@
+class MystatusesController < ApplicationController
+  DAYS = 30
+
+  def show
+    @daily_series = build_daily_series(current_user, days: DAYS)
+  end
+
+  private
+
+  # daily_series を直近 DAYS 日の枠に展開し、欠損日は light_time_minutes=0, desired_self_percentage=nil で埋める
+  # desired_self_percentage は 0〜100 のパーセント表記に変換
+  def build_daily_series(user, days:)
+    raw = ActivityRecord.daily_series(user, days: days)
+    by_date = raw.index_by { |row| row[:date] }
+    start_date = (days - 1).days.ago.in_time_zone.to_date
+
+    (0...days).map do |i|
+      date = start_date + i
+      row = by_date[date]
+      {
+        date: date,
+        light_time_minutes: row ? row[:light_time_minutes] : 0,
+        desired_self_percentage: row && row[:desired_self_percentage] ? (row[:desired_self_percentage] * 100).round(1) : nil
+      }
+    end
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -24,3 +24,6 @@ application.register("pomodoro-setting-modal", PomodoroSettingModalController)
 
 import PurificationTimerController from "./purification_timer_controller"
 application.register("purification-timer", PurificationTimerController)
+
+import MystatusChartController from "./mystatus_chart_controller"
+application.register("mystatus-chart", MystatusChartController)

--- a/app/javascript/controllers/mystatus_chart_controller.js
+++ b/app/javascript/controllers/mystatus_chart_controller.js
@@ -1,0 +1,85 @@
+import { Controller } from "@hotwired/stimulus"
+import {
+  Chart,
+  BarController,
+  BarElement,
+  LineController,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler
+} from "chart.js"
+
+Chart.register(
+  BarController,
+  BarElement,
+  LineController,
+  LineElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  Filler
+)
+
+// Connects to data-controller="mystatus-chart"
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = {
+    type: String,
+    labels: Array,
+    data: Array,
+    label: String,
+    color: { type: String, default: "#facc15" },
+    yMax: { type: Number, default: 0 },
+    yLabelMax: { type: Number, default: 0 }
+  }
+
+  connect() {
+    this.chart = new Chart(this.canvasTarget, {
+      type: this.typeValue,
+      data: {
+        labels: this.labelsValue,
+        datasets: [{
+          label: this.labelValue,
+          data: this.dataValue,
+          backgroundColor: this.colorValue,
+          borderColor: this.colorValue,
+          borderWidth: 2,
+          fill: false,
+          tension: 0.2,
+          spanGaps: true,
+          pointRadius: 3
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: true, position: "top" }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: this.yMaxValue > 0 ? this.yMaxValue : undefined,
+            ticks: {
+              // yLabelMax を超える値はラベル非表示（軸自体は yMax まで描画される）
+              callback: (value) => (this.yLabelMaxValue > 0 && value > this.yLabelMaxValue) ? "" : value
+            }
+          }
+        }
+      }
+    })
+  }
+
+  disconnect() {
+    if (this.chart) {
+      this.chart.destroy()
+      this.chart = null
+    }
+  }
+}

--- a/app/models/activity_record.rb
+++ b/app/models/activity_record.rb
@@ -46,7 +46,7 @@ class ActivityRecord < ApplicationRecord
   end
 
   # 時系列グラフ用: 直近N日の日次集計（JST基準）
-  # light_time_minutes は SUM(total_duration) を分単位に丸めた Integer
+  # light_time_minutes は SUM(total_duration) の合計分数（total_duration は分単位で保存されている）
   # 該当レコードがない日は配列に含まれない
   def self.daily_series(user, days: 30)
     bucket = Arel.sql("DATE((created_at AT TIME ZONE 'UTC') AT TIME ZONE 'Asia/Tokyo')")
@@ -62,7 +62,7 @@ class ActivityRecord < ApplicationRecord
         .map do |date, total_duration_sum, desired_self_avg|
           {
             date: date,
-            light_time_minutes: (total_duration_sum.to_i / 60),
+            light_time_minutes: total_duration_sum.to_i,
             desired_self_percentage: desired_self_avg&.to_f
           }
         end

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -1,0 +1,54 @@
+<% labels = @daily_series.map { |row| row[:date].strftime("%-m/%-d") } %>
+<% light_time_minutes = @daily_series.map { |row| row[:light_time_minutes] } %>
+<% desired_self_percentages = @daily_series.map { |row| row[:desired_self_percentage] } %>
+
+<div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
+
+  <%= render "shared/hamburger_menu" %>
+
+  <div class="flex flex-col items-center pt-24 px-6 md:px-20 pb-12">
+    <h1 class="text-2xl md:text-3xl text-white font-semibold mb-8 drop-shadow">
+      マイステータス（直近30日）
+    </h1>
+
+    <!-- 光の時間 -->
+    <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
+      <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
+        光の時間（分／日）
+      </h2>
+      <div
+        data-controller="mystatus-chart"
+        data-mystatus-chart-type-value="bar"
+        data-mystatus-chart-labels-value="<%= labels.to_json %>"
+        data-mystatus-chart-data-value="<%= light_time_minutes.to_json %>"
+        data-mystatus-chart-label-value="光の時間（分）"
+        data-mystatus-chart-color-value="#facc15"
+        class="relative h-64 md:h-80"
+      >
+        <canvas data-mystatus-chart-target="canvas"></canvas>
+      </div>
+    </div>
+
+    <!-- 本来の自分 -->
+    <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
+      <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
+        本来の自分（％／日）
+      </h2>
+      <div
+        data-controller="mystatus-chart"
+        data-mystatus-chart-type-value="line"
+        data-mystatus-chart-labels-value="<%= labels.to_json %>"
+        data-mystatus-chart-data-value="<%= desired_self_percentages.to_json %>"
+        data-mystatus-chart-label-value="本来の自分（％）"
+        data-mystatus-chart-color-value="#60a5fa"
+        data-mystatus-chart-y-max-value="110"
+        data-mystatus-chart-y-label-max-value="100"
+        class="relative h-64 md:h-80"
+      >
+        <canvas data-mystatus-chart-target="canvas"></canvas>
+      </div>
+    </div>
+
+    <%= link_to "マイページに戻る", mypage_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 text-zinc-800 font-semibold shadow transition duration-200" %>
+  </div>
+</div>

--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -20,6 +20,7 @@
       <ul class="pt-35 last:border-b last:border-amber-500">
         <li><%= link_to "マイページ", mypage_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mypage_path) %></li>
         <li><%= link_to "活動記録", activity_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(activity_records_path) %></li>
+        <li><%= link_to "マイステータス", mystatus_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mystatus_path) %></li>
       </ul>
     </nav>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
   root "static_pages#home" # ホーム画面をルートパスに設定
 
   resource :mypage, only: %i[show]
+  # マイステータス（時系列グラフ）
+  resource :mystatus, only: %i[show]
   # 闇の時間の活動内容
   resource :dark_time, only: %i[new create show edit update]
   # 光の時間の活動内容

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.23",
     "@tailwindcss/cli": "^4.2.1",
+    "chart.js": "^4.5.1",
     "tailwindcss": "^4.2.1"
   }
 }

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -435,9 +435,9 @@ RSpec.describe ActivityRecord, type: :model do
       end
 
       it "同日の合計時間が分単位で合算されること" do
-        # SUM(60 + 120) / 60 = 3 分
+        # SUM(60 + 120) = 180 分
         expect(series.size).to eq 1
-        expect(series.first[:light_time_minutes]).to eq 3
+        expect(series.first[:light_time_minutes]).to eq 180
       end
 
       it "同日の本来の自分が平均化されること" do

--- a/spec/requests/mystatuses_spec.rb
+++ b/spec/requests/mystatuses_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "Mystatuses", type: :request do
+  let(:user) { create(:user) }
+  let(:light_time) { create(:light_time, :current, user: user) }
+
+  describe "GET /mystatus" do
+    context "ログイン済みのとき" do
+      before { sign_in user }
+
+      it "200 が返り、タイトルが表示されること" do
+        get mystatus_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("マイステータス")
+        end
+      end
+
+      it "活動記録が存在しても 200 が返ること" do
+        create(:activity_record, user: user)
+
+        get mystatus_path
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "活動記録のない日は light_time の data 属性が 30 個の 0 配列として埋め込まれること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          get mystatus_path
+        end
+
+        expected_array = "[#{Array.new(30, 0).join(",")}]"
+        expect(response.body).to include(%(data-mystatus-chart-data-value="#{expected_array}"))
+      end
+
+      it "活動記録がある日は light_time の data 属性に合計分数が含まれること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          create(:activity_record, user: user, light_time: light_time,
+                                   total_duration: 90, idle_duration: 10)
+
+          get mystatus_path
+        end
+
+        # 30日分の末尾（=本日）に 90 が入る
+        expected_array = "[#{(Array.new(29, 0) + [ 90 ]).join(",")}]"
+        expect(response.body).to include(%(data-mystatus-chart-data-value="#{expected_array}"))
+      end
+
+      it "本来の自分の data 属性に desired_self_percentage が % 単位で含まれること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          # (90 - 10) / 90 ≒ 0.8888... → DB の decimal(5,2) で 0.89 に丸め → *100 で 89.0
+          create(:activity_record, user: user, light_time: light_time,
+                                   total_duration: 90, idle_duration: 10)
+
+          get mystatus_path
+        end
+
+        # 本来の自分のチャート用 data 属性に 89.0 が含まれる（記録のない日は null）
+        expect(response.body).to match(/data-mystatus-chart-data-value="\[[^"]*89\.0\]"/)
+      end
+    end
+
+    context "未ログインのとき" do
+      it "ログインページへリダイレクトされること" do
+        get mystatus_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/mystatuses_spec.rb
+++ b/spec/system/mystatuses_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "Mystatuses システムテスト", type: :system do
+  let(:user) { create(:user) }
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before { sign_in user }
+
+  describe "マイステータスページ" do
+    it "タイトルとグラフ用 canvas が 2 つ表示されること" do
+      visit mystatus_path
+
+      aggregate_failures do
+        expect(page).to have_content("マイステータス")
+        expect(page).to have_content("光の時間")
+        expect(page).to have_content("本来の自分")
+        expect(page).to have_css("canvas", count: 2)
+      end
+    end
+
+    it "マイページに戻るリンクからマイページへ遷移できること" do
+      visit mystatus_path
+      click_link "マイページに戻る"
+
+      expect(page).to have_current_path(mypage_path)
+    end
+  end
+
+  describe "マイページのハンバーガーメニューからの遷移" do
+    it "「マイステータス」リンクからマイステータスページに遷移できること" do
+      visit mypage_path
+      # ハンバーガーメニューを開いてから遷移
+      find('button[aria-label="メニュー"]').click
+      click_link "マイステータス"
+
+      expect(page).to have_current_path(mystatus_path)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@napi-rs/wasm-runtime@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
@@ -426,6 +431,13 @@
   integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
   dependencies:
     tslib "^2.4.0"
+
+chart.js@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.1.tgz#19dd1a9a386a3f6397691672231cb5fc9c052c35"
+  integrity sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 detect-libc@^2.0.3:
   version "2.1.2"


### PR DESCRIPTION
## Summary

- ハンバーガーメニューから遷移できる `/mystatus` ページを新設し、Chart.js + Stimulus で **光の時間（分／日）** を棒グラフ、**本来の自分（％／日）** を折れ線グラフで直近30日分表示する
- `ActivityRecord.daily_series` の `total_duration_sum / 60` を削除（PR #170 で混入していた単位ミス。`total_duration` は分単位保存のため 60 で割ると 60 分未満のセッションが 0 に丸められていた）
- 本来の自分のグラフは 100% プロットが見切れないよう y 軸を 110 まで描画しつつ、110 のラベルのみ非表示にしてユーザーには「0〜100」のスケールに見えるように調整

## Test plan

- [ ] `docker compose exec web bundle exec rspec spec/models/activity_record_spec.rb` がパスする
- [ ] `docker compose exec web bundle exec rspec spec/requests/mystatuses_spec.rb` がパスする
- [ ] `docker compose exec web bundle exec rspec spec/system/mystatuses_spec.rb` がパスする
- [ ] マイページのハンバーガーメニューから「マイステータス」をクリックして `/mystatus` に遷移できる
- [ ] 活動記録がある日は棒グラフに分数が反映され、ない日は 0 として描画される
- [ ] 本来の自分の折れ線グラフは線として描画され（塗り潰しではない）、100% のデータ点が見切れない
- [ ] 「マイページに戻る」リンクからマイページへ戻れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)