### PR TITLE
feat: マイステータスに評価レーダーと本来の自分の14日平均を追加

### DIFF
--- a/app/controllers/mystatuses_controller.rb
+++ b/app/controllers/mystatuses_controller.rb
@@ -1,11 +1,20 @@
 class MystatusesController < ApplicationController
-  DAYS = 30
+  DAYS = 14
 
   def show
     @daily_series = build_daily_series(current_user, days: DAYS)
+    @evaluation_averages = ActivityRecord.evaluation_averages(current_user, days: DAYS)
+    @fatigue_average = ActivityRecord.fatigue_average(current_user, days: DAYS)
+    @desired_self_percentage_average = build_desired_self_percentage_average(current_user, days: DAYS)
   end
 
   private
+
+  # 直近 DAYS 日の本来の自分の平均を 0〜100 のパーセント表記で返す（記録なしは nil）
+  def build_desired_self_percentage_average(user, days:)
+    avg = ActivityRecord.desired_self_percentage_average(user, days: days)
+    avg ? (avg * 100).round(1) : nil
+  end
 
   # daily_series を直近 DAYS 日の枠に展開し、欠損日は light_time_minutes=0, desired_self_percentage=nil で埋める
   # desired_self_percentage は 0〜100 のパーセント表記に変換

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -27,3 +27,6 @@ application.register("purification-timer", PurificationTimerController)
 
 import MystatusChartController from "./mystatus_chart_controller"
 application.register("mystatus-chart", MystatusChartController)
+
+import MystatusRadarChartController from "./mystatus_radar_chart_controller"
+application.register("mystatus-radar-chart", MystatusRadarChartController)

--- a/app/javascript/controllers/mystatus_radar_chart_controller.js
+++ b/app/javascript/controllers/mystatus_radar_chart_controller.js
@@ -1,0 +1,74 @@
+import { Controller } from "@hotwired/stimulus"
+import {
+  Chart,
+  RadarController,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+} from "chart.js"
+
+Chart.register(
+  RadarController,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend
+)
+
+// Connects to data-controller="mystatus-radar-chart"
+export default class extends Controller {
+  static targets = ["canvas"]
+  static values = {
+    labels: Array,
+    data: Array,
+    label: { type: String, default: "評価" },
+    color: { type: String, default: "#34d399" },
+    fillColor: { type: String, default: "rgba(52, 211, 153, 0.2)" },
+    max: { type: Number, default: 5 },
+    showLegend: { type: Boolean, default: false }
+  }
+
+  connect() {
+    this.chart = new Chart(this.canvasTarget, {
+      type: "radar",
+      data: {
+        labels: this.labelsValue,
+        datasets: [{
+          label: this.labelValue,
+          data: this.dataValue,
+          backgroundColor: this.fillColorValue,
+          borderColor: this.colorValue,
+          pointBackgroundColor: this.colorValue,
+          borderWidth: 2
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: this.showLegendValue, position: "top" }
+        },
+        scales: {
+          r: {
+            min: 0,
+            max: this.maxValue,
+            ticks: { stepSize: 1 },
+            pointLabels: { font: { size: 13 } }
+          }
+        }
+      }
+    })
+  }
+
+  disconnect() {
+    if (this.chart) {
+      this.chart.destroy()
+      this.chart = null
+    }
+  }
+}

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -2,50 +2,98 @@
 <% light_time_minutes = @daily_series.map { |row| row[:light_time_minutes] } %>
 <% desired_self_percentages = @daily_series.map { |row| row[:desired_self_percentage] } %>
 
+<%# レーダーチャート用（満足度・進行度・作業の質・集中度）。疲労感は逆指標のため別表示 %>
+<% radar_items = [["満足度", :satisfaction], ["進行度", :progress], ["作業の質", :quality], ["集中度", :focus]] %>
+<% radar_labels = radar_items.map(&:first) %>
+<% radar_values = radar_items.map { |_, key| @evaluation_averages[key]&.round(1) || 0 } %>
+<% has_evaluation = @evaluation_averages.values.any?(&:present?) %>
+
 <div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
 
   <%= render "shared/hamburger_menu" %>
 
   <div class="flex flex-col items-center pt-24 px-6 md:px-20 pb-12">
-    <h1 class="text-2xl md:text-3xl text-white font-semibold mb-8 drop-shadow">
-      マイステータス（直近30日）
+    <h1 class="text-2xl md:text-3xl text-white font-semibold mb-24 drop-shadow">
+      マイステータス（直近14日）
     </h1>
 
-    <!-- 光の時間 -->
-    <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
-      <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
-        光の時間（分／日）
-      </h2>
-      <div
-        data-controller="mystatus-chart"
-        data-mystatus-chart-type-value="bar"
-        data-mystatus-chart-labels-value="<%= labels.to_json %>"
-        data-mystatus-chart-data-value="<%= light_time_minutes.to_json %>"
-        data-mystatus-chart-label-value="光の時間（分）"
-        data-mystatus-chart-color-value="#facc15"
-        class="relative h-64 md:h-80"
-      >
-        <canvas data-mystatus-chart-target="canvas"></canvas>
-      </div>
+    <!-- 本来の自分（直近14日平均） -->
+    <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl px-6 py-12 mb-24 text-center">
+      <p class="text-zinc-800 text-sm md:text-base font-semibold">本来の自分（直近14日平均）</p>
+      <p class="text-5xl md:text-6xl font-bold text-amber-600 leading-tight wrap-break-word">
+        <%= @desired_self_percentage_average ? "#{@desired_self_percentage_average}%" : "—" %>
+      </p>
     </div>
 
-    <!-- 本来の自分 -->
-    <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
-      <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
-        本来の自分（％／日）
-      </h2>
-      <div
-        data-controller="mystatus-chart"
-        data-mystatus-chart-type-value="line"
-        data-mystatus-chart-labels-value="<%= labels.to_json %>"
-        data-mystatus-chart-data-value="<%= desired_self_percentages.to_json %>"
-        data-mystatus-chart-label-value="本来の自分（％）"
-        data-mystatus-chart-color-value="#60a5fa"
-        data-mystatus-chart-y-max-value="110"
-        data-mystatus-chart-y-label-max-value="100"
-        class="relative h-64 md:h-80"
-      >
-        <canvas data-mystatus-chart-target="canvas"></canvas>
+    <!-- グラフ（すべて縦積み。上から 本来の自分 → 光の時間 → 評価レーダー） -->
+    <div class="w-full max-w-3xl mb-8">
+      <!-- 本来の自分 -->
+      <div class="bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
+        <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
+          本来の自分（％／日）
+        </h2>
+        <div
+          data-controller="mystatus-chart"
+          data-mystatus-chart-type-value="line"
+          data-mystatus-chart-labels-value="<%= labels.to_json %>"
+          data-mystatus-chart-data-value="<%= desired_self_percentages.to_json %>"
+          data-mystatus-chart-label-value="本来の自分（％）"
+          data-mystatus-chart-color-value="#60a5fa"
+          data-mystatus-chart-y-max-value="110"
+          data-mystatus-chart-y-label-max-value="100"
+          class="relative h-64 md:h-80"
+        >
+          <canvas data-mystatus-chart-target="canvas"></canvas>
+        </div>
+      </div>
+
+      <!-- 光の時間 -->
+      <div class="bg-stone-300/80 rounded-2xl shadow-xl p-6 mb-8">
+        <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
+          光の時間（分／日）
+        </h2>
+        <div
+          data-controller="mystatus-chart"
+          data-mystatus-chart-type-value="bar"
+          data-mystatus-chart-labels-value="<%= labels.to_json %>"
+          data-mystatus-chart-data-value="<%= light_time_minutes.to_json %>"
+          data-mystatus-chart-label-value="光の時間（分）"
+          data-mystatus-chart-color-value="#facc15"
+          class="relative h-64 md:h-80"
+        >
+          <canvas data-mystatus-chart-target="canvas"></canvas>
+        </div>
+      </div>
+
+      <!-- 評価レーダー -->
+      <div class="bg-stone-300/80 rounded-2xl shadow-xl p-6">
+        <h2 class="text-lg md:text-xl text-zinc-800 font-semibold mb-4 text-center">
+          評価レーダー
+        </h2>
+
+        <% if has_evaluation %>
+          <div
+            data-controller="mystatus-radar-chart"
+            data-mystatus-radar-chart-labels-value="<%= radar_labels.to_json %>"
+            data-mystatus-radar-chart-data-value="<%= radar_values.to_json %>"
+            data-mystatus-radar-chart-label-value="評価（5段階）"
+            data-mystatus-radar-chart-color-value="#34d399"
+            data-mystatus-radar-chart-show-legend-value="true"
+            class="relative h-72 md:h-80"
+          >
+            <canvas data-mystatus-radar-chart-target="canvas"></canvas>
+          </div>
+
+          <!-- 疲労感（逆指標のためレーダーから分離して別表示） -->
+          <p class="mt-4 text-center text-zinc-800">
+            疲労感（低いほど良い）:
+            <span class="font-semibold">
+              <%= @fatigue_average ? "#{@fatigue_average.round(1)} / 5" : "データなし" %>
+            </span>
+          </p>
+        <% else %>
+          <p class="text-center text-zinc-600 py-8">まだ評価データがありません</p>
+        <% end %>
       </div>
     </div>
 

--- a/spec/requests/mystatuses_spec.rb
+++ b/spec/requests/mystatuses_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe "Mystatuses", type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it "活動記録のない日は light_time の data 属性が 30 個の 0 配列として埋め込まれること" do
+      it "活動記録のない日は light_time の data 属性が 14 個の 0 配列として埋め込まれること" do
         travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
           get mystatus_path
         end
 
-        expected_array = "[#{Array.new(30, 0).join(",")}]"
+        expected_array = "[#{Array.new(14, 0).join(",")}]"
         expect(response.body).to include(%(data-mystatus-chart-data-value="#{expected_array}"))
       end
 
@@ -42,8 +42,8 @@ RSpec.describe "Mystatuses", type: :request do
           get mystatus_path
         end
 
-        # 30日分の末尾（=本日）に 90 が入る
-        expected_array = "[#{(Array.new(29, 0) + [ 90 ]).join(",")}]"
+        # 14日分の末尾（=本日）に 90 が入る
+        expected_array = "[#{(Array.new(13, 0) + [ 90 ]).join(",")}]"
         expect(response.body).to include(%(data-mystatus-chart-data-value="#{expected_array}"))
       end
 
@@ -58,6 +58,55 @@ RSpec.describe "Mystatuses", type: :request do
 
         # 本来の自分のチャート用 data 属性に 89.0 が含まれる（記録のない日は null）
         expect(response.body).to match(/data-mystatus-chart-data-value="\[[^"]*89\.0\]"/)
+      end
+
+      it "本来の自分の14日平均がパーセント表記で大きく表示されること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          # (90 - 10) / 90 → decimal(5,2) で 0.89 → *100 で 89.0%
+          create(:activity_record, user: user, light_time: light_time,
+                                   total_duration: 90, idle_duration: 10)
+
+          get mystatus_path
+        end
+
+        aggregate_failures do
+          expect(response.body).to include("本来の自分（直近14日平均）")
+          expect(response.body).to include("89.0%")
+        end
+      end
+
+      it "評価レーダーの data 属性に4項目の平均値が含まれること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          create(:activity_record, user: user, light_time: light_time,
+                                   satisfaction: 4, progress: 4, quality: 4, focus: 4, fatigue: 2)
+
+          get mystatus_path
+        end
+
+        # 満足度・進行度・作業の質・集中度の順に平均値（ここでは全て 4.0）
+        expect(response.body).to include(%(data-mystatus-radar-chart-data-value="[4.0,4.0,4.0,4.0]"))
+      end
+
+      it "疲労感が逆指標である旨と平均値が表示されること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          create(:activity_record, user: user, light_time: light_time, fatigue: 2)
+
+          get mystatus_path
+        end
+
+        aggregate_failures do
+          expect(response.body).to include("疲労感（低いほど良い）")
+          expect(response.body).to include("2.0 / 5")
+        end
+      end
+
+      it "評価データがない場合はレーダーの代わりに案内文が表示されること" do
+        get mystatus_path
+
+        aggregate_failures do
+          expect(response.body).to include("まだ評価データがありません")
+          expect(response.body).not_to include("data-mystatus-radar-chart-data-value")
+        end
       end
     end
 

--- a/spec/system/mystatuses_spec.rb
+++ b/spec/system/mystatuses_spec.rb
@@ -8,14 +8,19 @@ RSpec.describe "Mystatuses システムテスト", type: :system do
   before { sign_in user }
 
   describe "マイステータスページ" do
-    it "タイトルとグラフ用 canvas が 2 つ表示されること" do
+    it "タイトルとグラフ用 canvas が 3 つ表示されること" do
+      create(:activity_record, user: user, light_time: light_time)
+
       visit mystatus_path
 
       aggregate_failures do
         expect(page).to have_content("マイステータス")
         expect(page).to have_content("光の時間")
         expect(page).to have_content("本来の自分")
-        expect(page).to have_css("canvas", count: 2)
+        expect(page).to have_content("評価レーダー")
+        expect(page).to have_content("疲労感（低いほど良い）")
+        # ignore_hidden_elements = false のため、Turbo キャッシュ由来の隠れ canvas を除外して可視のみ数える
+        expect(page).to have_css("canvas", count: 3, visible: true)
       end
     end
 


### PR DESCRIPTION
## Summary

マイステータスページに評価レーダーチャートと「本来の自分」の期間平均表示を追加し、集計期間を 14 日に統一しました。

- **集計期間を 30 日 → 14 日に統一**（README 準拠）。時系列グラフ・レーダー・平均すべて 14 日
- **本来の自分（直近14日平均）** をタイトル下にパーセント表記で大きく表示
- **評価レーダーチャート**（満足度・進行度・作業の質・集中度の4項目）を追加
  - 疲労感は逆指標（高いほど悪い）のためレーダーから分離し、「疲労感（低いほど良い）: x.x / 5」として別表示
- 評価データがない場合は「まだ評価データがありません」を表示し canvas を描画しない
- レイアウトは全画面幅で縦積み（上から 平均バナー → 本来の自分 → 光の時間 → 評価レーダー）
- `mystatus_radar_chart_controller`: 凡例の表示有無を `show-legend` 値で制御できる汎用コントローラ

## 設計メモ

- 疲労感をレーダーに素のまま載せると「疲れているほど面積が広く=良く見える」誤読が生じるため、ドメイン上の逆指標として分離表示しています（既存の `RADAR_FIELDS` 除外・`fatigue_average` 分離の設計に一致）
- 本来の自分の平均は `desired_self_percentage` が `decimal(5,2)` のため、表示は小数1桁（例: 89.0%）になります

## Test plan

- [x] `docker compose exec web bundle exec rspec spec/requests/mystatuses_spec.rb` がパスする
- [x] `docker compose exec web bundle exec rspec spec/system/mystatuses_spec.rb` がパスする
- [x] レーダーチャートに4項目の平均が描画される
- [x] 疲労感が「低いほど良い」と明記され平均値が表示される
- [x] 評価データがないユーザーで案内文が表示され、グラフが描画されない
- [x] 本来の自分の14日平均がタイトル下に大きく表示される
- [x] スマホ幅・PC幅いずれでも縦積みで崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)