### PR TITLE
refactor: 本来の自分のパーセント表記を display_percentage に統一（issue #175）

### DIFF
--- a/app/controllers/mystatuses_controller.rb
+++ b/app/controllers/mystatuses_controller.rb
@@ -5,16 +5,11 @@ class MystatusesController < ApplicationController
     @daily_series = build_daily_series(current_user, days: DAYS)
     @evaluation_averages = ActivityRecord.evaluation_averages(current_user, days: DAYS)
     @fatigue_average = ActivityRecord.fatigue_average(current_user, days: DAYS)
-    @desired_self_percentage_average = build_desired_self_percentage_average(current_user, days: DAYS)
+    # 0〜1 の生の平均をそのまま渡し、パーセント表記はビューの display_percentage に委譲（記録なしは nil）
+    @desired_self_percentage_average = ActivityRecord.desired_self_percentage_average(current_user, days: DAYS)
   end
 
   private
-
-  # 直近 DAYS 日の本来の自分の平均を 0〜100 のパーセント表記で返す（記録なしは nil）
-  def build_desired_self_percentage_average(user, days:)
-    avg = ActivityRecord.desired_self_percentage_average(user, days: days)
-    avg ? (avg * 100).round(1) : nil
-  end
 
   # daily_series を直近 DAYS 日の枠に展開し、欠損日は light_time_minutes=0, desired_self_percentage=nil で埋める
   # desired_self_percentage は 0〜100 のパーセント表記に変換

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,9 +16,9 @@ module ApplicationHelper
   end
 
   def display_percentage(value)
-    return "未設定" if value.blank?
+    return nil if value.blank?
 
-    "#{(value * 100).round} %"
+    "#{(value * 100).round(1)} %"
   end
 
   def nav_link_class(path)

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -40,7 +40,7 @@
 
     <!-- 今日の本来の自分 -->
     <p class="mb-6">
-      今日の本来の自分: <span class="bg-amber-500 px-3 py-1 rounded"><%= display_percentage(@activity_record.desired_self_percentage) %></span>
+      今日の本来の自分: <span class="bg-amber-500 px-3 py-1 rounded"><%= display_percentage(@activity_record.desired_self_percentage) || "未設定" %></span>
     </p>
 
     <!-- 満足度、進行度、作業の質、集中度、疲労感 -->

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -21,7 +21,7 @@
     <div class="w-full max-w-3xl bg-stone-300/80 rounded-2xl shadow-xl px-6 py-12 mb-24 text-center">
       <p class="text-zinc-800 text-sm md:text-base font-semibold">本来の自分（直近14日平均）</p>
       <p class="text-5xl md:text-6xl font-bold text-amber-600 leading-tight wrap-break-word">
-        <%= @desired_self_percentage_average ? "#{@desired_self_percentage_average}%" : "—" %>
+        <%= display_percentage(@desired_self_percentage_average) || "—" %>
       </p>
     </div>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,20 +35,20 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#display_percentage" do
-    it "nil のとき「未設定」を返すこと" do
-      expect(helper.display_percentage(nil)).to eq "未設定"
+    it "nil のとき nil を返すこと(表示文言はビュー側に委譲)" do
+      expect(helper.display_percentage(nil)).to be_nil
     end
 
-    it "0.8 を「80 %」に変換すること" do
-      expect(helper.display_percentage(0.8)).to eq "80 %"
+    it "0.8 を「80.0 %」に変換すること(小数1桁)" do
+      expect(helper.display_percentage(0.8)).to eq "80.0 %"
     end
 
-    it "0.125 を「13 %」に変換すること(四捨五入)" do
-      expect(helper.display_percentage(0.125)).to eq "13 %"
+    it "0.125 を「12.5 %」に変換すること(小数1桁に四捨五入)" do
+      expect(helper.display_percentage(0.125)).to eq "12.5 %"
     end
 
-    it "1.0 を「100 %」に変換すること" do
-      expect(helper.display_percentage(1.0)).to eq "100 %"
+    it "1.0 を「100.0 %」に変換すること" do
+      expect(helper.display_percentage(1.0)).to eq "100.0 %"
     end
   end
 

--- a/spec/requests/mystatuses_spec.rb
+++ b/spec/requests/mystatuses_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Mystatuses", type: :request do
 
       it "本来の自分の14日平均がパーセント表記で大きく表示されること" do
         travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
-          # (90 - 10) / 90 → decimal(5,2) で 0.89 → *100 で 89.0%
+          # (90 - 10) / 90 → decimal(5,2) で 0.89 → display_percentage で「89.0 %」
           create(:activity_record, user: user, light_time: light_time,
                                    total_duration: 90, idle_duration: 10)
 
@@ -71,7 +71,7 @@ RSpec.describe "Mystatuses", type: :request do
 
         aggregate_failures do
           expect(response.body).to include("本来の自分（直近14日平均）")
-          expect(response.body).to include("89.0%")
+          expect(response.body).to include("89.0 %")
         end
       end
 


### PR DESCRIPTION
## 概要
マイステータスのバナーでインラインに行っていたパーセント変換（`(avg * 100).round(1)`）を廃し、表記を `display_percentage` ヘルパーに一本化しました（issue #175）。ロジックの二重化を解消します。

## 主な変更
- **ヘルパー** `display_percentage` を「値があれば小数1桁＋スペース＋`%`、なければ `nil`」の単一責務に整理。`blank:` / `precision:` / `space:` 引数を段階的に廃止し、空欄時の表示文言は各ビューが `||` で指定（マイステータス: `—`、活動記録: `未設定`）
- **コントローラー** `mystatuses_controller` から `build_desired_self_percentage_average` を削除し、0〜1 の生平均をそのまま渡してパーセント変換はビューに委譲
- **表示の統一** 「本来の自分」を両画面で小数1桁・スペースありに統一（活動記録「今日の本来の自分」: `89 %` → `89.0 %`）

## スコープ外
- チャート用の数値（`build_daily_series` 内の変換）は、JSON配列に渡す数値であり文字列化してはいけないため対象外（コントローラーに残置）

## 表示の変化
| 箇所 | 変更前 | 変更後 |
|---|---|---|
| マイステータス14日平均 | `89.0%` | `89.0 %` |
| 活動記録「今日の本来の自分」 | `89 %` | `89.0 %` |
| データなし | `—` / `未設定` | `—` / `未設定`（不変） |

## テスト
- `spec/helpers/application_helper_spec.rb`: 新仕様（nil→`be_nil`、小数1桁）に更新
- `spec/requests/mystatuses_spec.rb`: バナーの期待値を `89.0 %` に更新
- ローカルで helper / mystatus / activity_record の関連スペックは全てパス（rubocop も offenses なし）

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)