### PR TITLE
feat: 本来の自分を X でシェアする機能を追加

### DIFF
--- a/app/helpers/x_share_helper.rb
+++ b/app/helpers/x_share_helper.rb
@@ -1,0 +1,44 @@
+module XShareHelper
+  # X（Twitter）の投稿画面 Web Intent。テキストのみ渡せる（画像は添付不可）
+  X_INTENT_URL = "https://twitter.com/intent/tweet".freeze
+
+  # ハッシュタグ（# は付けない。X 側が自動付与する）
+  SERVICE_HASHTAG   = "GetTheTime".freeze
+  OVERALL_HASHTAGS  = [ SERVICE_HASHTAG, "本来の自分" ].freeze       # 本来の自分（平均）向け
+  ACTIVITY_HASHTAGS = [ SERVICE_HASHTAG, "今日の本来の自分" ].freeze # 今日の本来の自分（活動記録）向け
+
+  # 「本来の自分」シェア文面（マイステータスの平均向け）
+  #   例: 「2026年6月2日の本来の自分は 89.0 % です」
+  #   パーセント表記は共通の display_percentage に委譲（呼び出し側で present? を担保済み）
+  def x_share_overall_text(percentage, date: Time.current)
+    "#{format_date_ja(date)}の本来の自分は #{display_percentage(percentage)} です"
+  end
+
+  # 「今日の本来の自分」シェア文面（活動記録向け）
+  #   例: 「2026年6月2日14時30分開始の活動における今日の本来の自分は 89.0 % です」
+  def x_share_activity_text(percentage, started_at:)
+    "#{format_date_ja(started_at)}#{format_time_ja(started_at)}開始の活動における今日の本来の自分は #{display_percentage(percentage)} です"
+  end
+
+  # 投稿本文を「本文 → ハッシュタグ → URL」の順に改行で組み立てる。
+  # 並び順を X 任せにせずこちらで確定させるため、URL もハッシュタグも text に含める。
+  def x_share_message(body, hashtags: nil, url: nil)
+    hashtag_line = Array(hashtags).map { |tag| "##{tag}" }.join(" ")
+    [ body, hashtag_line, url ].reject(&:blank?).join("\n")
+  end
+
+  # X 投稿画面の URL。並び順を確定させた本文を text にまとめて載せる
+  def x_intent_url(text)
+    "#{X_INTENT_URL}?#{{ text: text }.to_query}"
+  end
+
+  # 日本語の日付表記（JST）。例: "2026年6月2日"
+  def format_date_ja(time)
+    time.in_time_zone("Tokyo").strftime("%Y年%-m月%-d日")
+  end
+
+  # 日本語の時刻表記（JST）。例: "14時30分"
+  def format_time_ja(time)
+    time.in_time_zone("Tokyo").strftime("%-H時%-M分")
+  end
+end

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -43,6 +43,15 @@
       今日の本来の自分: <span class="bg-amber-500 px-3 py-1 rounded"><%= display_percentage(@activity_record.desired_self_percentage) || "未計測" %></span>
     </p>
 
+    <!-- X でシェア -->
+    <% if @activity_record.desired_self_percentage.present? %>
+      <div class="mb-6">
+        <%= render "shared/x_share_button",
+              text: x_share_activity_text(@activity_record.desired_self_percentage, started_at: @activity_record.started_at),
+              hashtags: XShareHelper::ACTIVITY_HASHTAGS %>
+      </div>
+    <% end %>
+
     <!-- 満足度、進行度、作業の質、集中度、疲労感 -->
     <div class="space-y-2 mb-6">
       <% [

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,15 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%# OGP / Twitter Card（SNS シェア用。既定はサービス紹介カード） %>
+    <meta property="og:site_name" content="Get The Time">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="<%= content_for(:og_title).presence || "Get The Time" %>">
+    <meta property="og:description" content="<%= content_for(:og_description).presence || "自由時間を「光の時間」と「闇の時間」に分け、本来の自分を計測するサービス" %>">
+    <meta property="og:url" content="<%= request.original_url %>">
+    <meta property="og:image" content="<%= image_url("ogp.png") %>">
+    <meta name="twitter:card" content="summary_large_image">
+
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -23,6 +23,14 @@
       <p class="text-5xl md:text-6xl font-bold text-amber-600 leading-tight wrap-break-word">
         <%= display_percentage(@desired_self_percentage_average) || "—" %>
       </p>
+
+      <% if @desired_self_percentage_average.present? %>
+        <div class="mt-8">
+          <%= render "shared/x_share_button",
+                text: x_share_overall_text(@desired_self_percentage_average),
+                hashtags: XShareHelper::OVERALL_HASHTAGS %>
+        </div>
+      <% end %>
     </div>
 
     <!-- グラフ（すべて縦積み。上から 本来の自分 → 光の時間 → 評価レーダー） -->

--- a/app/views/shared/_x_share_button.html.erb
+++ b/app/views/shared/_x_share_button.html.erb
@@ -1,0 +1,17 @@
+<%#
+  X（Twitter）シェアボタン。
+  文面（％入り）と共有先 URL を載せて X の投稿画面を開く。
+  画像は共有先 URL の OGP カードとして表示される（既存の ogp.png を使用）。
+
+  locals:
+    text:     投稿本文（必須）
+    url:      共有する URL（任意。既定はトップページ）
+    hashtags: 付与するハッシュタグ配列（任意）
+%>
+<% message = x_share_message(text, hashtags: local_assigns[:hashtags], url: local_assigns.fetch(:url, root_url)) %>
+<%= link_to x_intent_url(message),
+      target: "_blank",
+      rel: "noopener",
+      class: "inline-flex items-center gap-2 bg-black text-white/90 px-5 py-2 rounded-full hover:bg-zinc-800 transition duration-200 font-semibold shadow" do %>
+  <span class="font-bold">𝕏</span> でシェア
+<% end %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,8 +43,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.display_percentage(0.8)).to eq "80.0 %"
     end
 
-    it "0.125 を「12.5 %」に変換すること(小数1桁に四捨五入)" do
-      expect(helper.display_percentage(0.125)).to eq "12.5 %"
+    it "小数第2位を四捨五入して第1位までにすること" do
+      aggregate_failures do
+        expect(helper.display_percentage(0.3333)).to eq "33.3 %" # 切り下げ
+        expect(helper.display_percentage(0.6666)).to eq "66.7 %" # 切り上げ
+      end
     end
 
     it "1.0 を「100.0 %」に変換すること" do

--- a/spec/helpers/x_share_helper_spec.rb
+++ b/spec/helpers/x_share_helper_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe XShareHelper, type: :helper do
+  describe "#format_date_ja" do
+    it "JST の和暦なし日本語日付表記（前ゼロなし）を返すこと" do
+      time = Time.zone.local(2026, 6, 2, 14, 30)
+      expect(helper.format_date_ja(time)).to eq "2026年6月2日"
+    end
+
+    it "UTC の時刻を JST に変換して日付を返すこと" do
+      # 2026-06-02 23:30 UTC は JST では 2026-06-03 08:30
+      time = Time.utc(2026, 6, 2, 23, 30)
+      expect(helper.format_date_ja(time)).to eq "2026年6月3日"
+    end
+  end
+
+  describe "#format_time_ja" do
+    it "JST の時刻表記（前ゼロなし）を返すこと" do
+      time = Time.zone.local(2026, 6, 2, 9, 5)
+      expect(helper.format_time_ja(time)).to eq "9時5分"
+    end
+  end
+
+  describe "#x_share_overall_text" do
+    it "「〜年〜月〜日の本来の自分は ◯◯ % です」の文面を返すこと" do
+      date = Time.zone.local(2026, 6, 2, 12, 0)
+      expect(helper.x_share_overall_text(0.89, date: date))
+        .to eq "2026年6月2日の本来の自分は 89.0 % です"
+    end
+  end
+
+  describe "#x_share_activity_text" do
+    it "「〜年〜月〜日〜時〜分開始の活動における今日の本来の自分は ◯◯ % です」の文面を返すこと" do
+      started_at = Time.zone.local(2026, 6, 2, 14, 30)
+      expect(helper.x_share_activity_text(0.5, started_at: started_at))
+        .to eq "2026年6月2日14時30分開始の活動における今日の本来の自分は 50.0 % です"
+    end
+  end
+
+  describe "#x_share_message" do
+    it "本文 → ハッシュタグ → URL の順に改行で組み立てること" do
+      message = helper.x_share_message("本文", hashtags: %w[GetTheTime 本来の自分], url: "https://example.com/")
+      expect(message).to eq "本文\n#GetTheTime #本来の自分\nhttps://example.com/"
+    end
+
+    it "ハッシュタグが無いときはその行を省くこと" do
+      message = helper.x_share_message("本文", url: "https://example.com/")
+      expect(message).to eq "本文\nhttps://example.com/"
+    end
+
+    it "URL が無いときは URL を省くこと" do
+      message = helper.x_share_message("本文", hashtags: %w[GetTheTime])
+      expect(message).to eq "本文\n#GetTheTime"
+    end
+  end
+
+  describe "#x_intent_url" do
+    it "テキストを URL エンコードして投稿画面 URL を返すこと" do
+      url = helper.x_intent_url("テスト 本来の自分")
+      aggregate_failures do
+        expect(url).to start_with("https://twitter.com/intent/tweet?")
+        expect(url).to include("text=#{CGI.escape("テスト 本来の自分")}")
+      end
+    end
+  end
+end

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -201,6 +201,22 @@ RSpec.describe "ActivityRecords", type: :request do
       get activity_record_path(other_activity_record)
       expect(response).to have_http_status(:not_found)
     end
+
+    it "本来の自分が計測済みのとき X 投稿画面へのリンクと文面が描画されること" do
+      record = create(:activity_record, user: user, light_time: light_time,
+                                        started_at: Time.zone.local(2026, 6, 2, 14, 30),
+                                        total_duration: 60, idle_duration: 30)
+
+      get activity_record_path(record)
+
+      expected_body = "2026年6月2日14時30分開始の活動における今日の本来の自分は 50.0 % です"
+      aggregate_failures do
+        expect(response.body).to include("でシェア")
+        expect(response.body).to include("twitter.com/intent/tweet")
+        expect(response.body).to include(CGI.escape(expected_body))
+        expect(response.body).to include(CGI.escape("#GetTheTime #今日の本来の自分"))
+      end
+    end
   end
 
   # =========================================================

--- a/spec/requests/mystatuses_spec.rb
+++ b/spec/requests/mystatuses_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe "Mystatuses", type: :request do
         end
       end
 
+      it "平均が存在するとき X 投稿画面へのリンクと文面が描画されること" do
+        travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
+          create(:activity_record, user: user, light_time: light_time,
+                                   total_duration: 90, idle_duration: 10)
+
+          get mystatus_path
+        end
+
+        aggregate_failures do
+          expect(response.body).to include("twitter.com/intent/tweet")
+          expect(response.body).to include(CGI.escape("2026年5月30日の本来の自分は 89.0 % です"))
+          expect(response.body).to include(CGI.escape("#GetTheTime #本来の自分"))
+        end
+      end
+
+      it "記録がなく平均が無いときは X シェアボタンを描画しないこと" do
+        get mystatus_path
+        expect(response.body).not_to include("twitter.com/intent/tweet")
+      end
+
       it "評価レーダーの data 属性に4項目の平均値が含まれること" do
         travel_to Time.zone.local(2026, 5, 30, 12, 0, 0) do
           create(:activity_record, user: user, light_time: light_time,

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,6 +1,27 @@
 require "rails_helper"
 
 RSpec.describe "StaticPages", type: :request do
+  describe "GET / (home)" do
+    it "200 が返り、SNS シェア用の OGP メタタグが描画されること" do
+      get root_path
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(%(name="twitter:card" content="summary_large_image"))
+        expect(response.body).to match(%r{property="og:image" content="[^"]*ogp[^"]*"})
+      end
+    end
+
+    it "content_for 未設定のとき og:title / og:description に既定値が入ること" do
+      get root_path
+
+      aggregate_failures do
+        expect(response.body).to include(%(property="og:title" content="Get The Time"))
+        expect(response.body).to include("自由時間を「光の時間」と「闇の時間」に分け、本来の自分を計測するサービス")
+      end
+    end
+  end
+
   describe "GET /reflection_guide" do
     context "ログイン済みのとき" do
       let(:user) { create(:user) }


### PR DESCRIPTION
## 概要

本来の自分の指標を X（Twitter）でシェアできる機能を追加します。closes #135

- **マイステータス**: 「本来の自分（直近14日平均）」をシェア
- **活動記録詳細**: 「今日の本来の自分」を、活動の日付・開始時刻つきでシェア

## 実装方針

X の Web Intent は画像を直接添付できないため、以下の構成にしました。

- **％は文面に含める** … 「2026年6月2日の本来の自分は 89.0 % です」のように本文へ記載
- **画像は OGP / Twitter Card で装飾表示** … 既存の `ogp.png` を `summary_large_image` カードとして表示（新規画像・手動添付は不要）
- **投稿本文の並び順を確定** … 「本文 → ハッシュタグ → URL」の順に組み立て、X 任せにしない
- **ハッシュタグをシェア種別で出し分け** … 平均=`#GetTheTime #本来の自分` / 活動=`#GetTheTime #今日の本来の自分`

## 投稿イメージ

```
2026年6月2日の本来の自分は 89.0 % です
#GetTheTime #本来の自分
https://（アプリのURL）

［OGP カード画像］
```

## 設計上のポイント

- シェア文面の整形ロジックは `XShareHelper` に集約。データ取得は既存アクションで充足しており、**コントローラは無変更**
- パーセント表記は共通の `display_percentage` に統一（DRY）
- 未計測時はシェアボタンを描画しない（`present?` ガード）

## テスト

- `spec/helpers/x_share_helper_spec.rb` … 文面生成・並び順・URL エンコード
- `spec/helpers/application_helper_spec.rb` … `display_percentage` の四捨五入（切り上げ／切り下げ）を補強
- `spec/requests/{activity_records,mystatuses}_spec.rb` … シェアリンク・文面・ハッシュタグの描画／非描画
- `spec/requests/static_pages_spec.rb` … OGP メタタグ（カードタイプ・画像・既定文言）

全 68 例グリーン / rubocop offense なし。

## 動作確認の注意

OGP カード画像は **本番環境（公開 URL）でのみ** X にスクレイピングされて表示されます。localhost では画像カードは確認できません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)