### PR TITLE
feat: 今日の本来の自分のシェア文面に活動時間を追加

### DIFF
--- a/app/helpers/x_share_helper.rb
+++ b/app/helpers/x_share_helper.rb
@@ -15,9 +15,10 @@ module XShareHelper
   end
 
   # 「今日の本来の自分」シェア文面（活動記録向け）
-  #   例: 「2026年6月2日14時30分開始の活動における今日の本来の自分は 89.0 % です」
-  def x_share_activity_text(percentage, started_at:)
-    "#{format_date_ja(started_at)}#{format_time_ja(started_at)}開始の活動における今日の本来の自分は #{display_percentage(percentage)} です"
+  #   例: 「2026年6月2日14時30分開始の約60分間の活動における今日の本来の自分は 89.0 % です」
+  #   total_duration は秒切り捨ての分なので「約」を付ける
+  def x_share_activity_text(percentage, started_at:, total_duration:)
+    "#{format_date_ja(started_at)}#{format_time_ja(started_at)}開始の約#{total_duration}分間の活動における今日の本来の自分は #{display_percentage(percentage)} です"
   end
 
   # 投稿本文を「本文 → ハッシュタグ → URL」の順に改行で組み立てる。

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -47,7 +47,7 @@
     <% if @activity_record.desired_self_percentage.present? %>
       <div class="mb-6">
         <%= render "shared/x_share_button",
-              text: x_share_activity_text(@activity_record.desired_self_percentage, started_at: @activity_record.started_at),
+              text: x_share_activity_text(@activity_record.desired_self_percentage, started_at: @activity_record.started_at, total_duration: @activity_record.total_duration),
               hashtags: XShareHelper::ACTIVITY_HASHTAGS %>
       </div>
     <% end %>

--- a/spec/helpers/x_share_helper_spec.rb
+++ b/spec/helpers/x_share_helper_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe XShareHelper, type: :helper do
   end
 
   describe "#x_share_activity_text" do
-    it "「〜年〜月〜日〜時〜分開始の活動における今日の本来の自分は ◯◯ % です」の文面を返すこと" do
+    it "「〜年〜月〜日〜時〜分開始の約〜分間の活動における今日の本来の自分は ◯◯ % です」の文面を返すこと" do
       started_at = Time.zone.local(2026, 6, 2, 14, 30)
-      expect(helper.x_share_activity_text(0.5, started_at: started_at))
-        .to eq "2026年6月2日14時30分開始の活動における今日の本来の自分は 50.0 % です"
+      expect(helper.x_share_activity_text(0.5, started_at: started_at, total_duration: 60))
+        .to eq "2026年6月2日14時30分開始の約60分間の活動における今日の本来の自分は 50.0 % です"
     end
   end
 

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe "ActivityRecords", type: :request do
 
       get activity_record_path(record)
 
-      expected_body = "2026年6月2日14時30分開始の活動における今日の本来の自分は 50.0 % です"
+      expected_body = "2026年6月2日14時30分開始の約60分間の活動における今日の本来の自分は 50.0 % です"
       aggregate_failures do
         expect(response.body).to include("でシェア")
         expect(response.body).to include("twitter.com/intent/tweet")


### PR DESCRIPTION
関連: #135（X シェア機能の追加改善）

## 概要

活動記録の「今日の本来の自分」を X でシェアする際の文面に、**活動の継続時間**を追加します。

**変更前**
```
2026年6月2日14時30分開始の活動における今日の本来の自分は 50.0 % です
```

**変更後**
```
2026年6月2日14時30分開始の約60分間の活動における今日の本来の自分は 50.0 % です
```

## 実装方針

- 継続時間は `ActivityRecord#total_duration` を使用（既存データ。コントローラ変更なし）
- `total_duration` はポモドーロ計測で**秒を切り捨てた「分」**（`Math.floor(... / 60000)`）のため、**「約」**を付与
- 時刻側の「14時30**分**」と区別するため、継続時間は**「分間」**と表記
- 1分未満（`total_duration` が 0）の場合はそのまま「約0分間」と表示（仕様として許容）

## 影響範囲

- `XShareHelper#x_share_activity_text` に `total_duration:` 引数を追加
- 活動記録詳細ビューの呼び出しを更新
- 平均（マイステータス）側は単一の活動時間を持たないため**変更なし**

## テスト

- `spec/helpers/x_share_helper_spec.rb` … 新文面の検証
- `spec/requests/activity_records_spec.rb` … 描画される文面を更新

39例グリーン / rubocop offense なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
