### PR TITLE
後悔した1日の記録機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@
 # 依存ライブラリの実体とキャッシュ
 /vendor/bundle
 /vendor/cache
+
+# Claude Code のローカル状態（メモリ等）
+/.claude/

--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -1,0 +1,25 @@
+class RegretRecordsController < ApplicationController
+  def index
+    @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page])
+  end
+
+  def new
+    @regret_record = current_user.regret_records.build
+  end
+
+  def create
+    @regret_record = current_user.regret_records.build(regret_record_params)
+    if @regret_record.save
+      redirect_to regret_records_path, notice: t("defaults.flash_message.created", item: RegretRecord.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: RegretRecord.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def regret_record_params
+    params.require(:regret_record).permit(:title, :content)
+  end
+end

--- a/app/models/regret_record.rb
+++ b/app/models/regret_record.rb
@@ -1,0 +1,5 @@
+class RegretRecord < ApplicationRecord
+  validates :content, presence: true
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :activity_records, dependent: :destroy
   has_one :purification_time, dependent: :destroy
   has_one :pomodoro_setting, dependent: :destroy
+  has_many :regret_records, dependent: :destroy
 
   after_create :create_pomodoro_setting
 end

--- a/app/views/activity_records/pomodoro/_motivation_button.html.erb
+++ b/app/views/activity_records/pomodoro/_motivation_button.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center mb-6">
-  <button type="button" data-action="click->pomodoro#toggleMotivation" class="bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-600 hover:via-indigo-500 hover:to-indigo-200 text-white/90 px-8 py-2 rounded-full font-semibold transition duration-200">
+  <button type="button" data-action="click->pomodoro#toggleMotivation" class="bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 text-white/90 px-8 py-2 rounded-full font-semibold transition duration-200">
     集中できない、やる気が出ないときは
   </button>
 </div>

--- a/app/views/mypages/_dark_time.html.erb
+++ b/app/views/mypages/_dark_time.html.erb
@@ -26,7 +26,7 @@
         登録されていません<br>
         新規登録しましょう
       </p>
-      <%= link_to "新規登録", new_dark_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-600 hover:via-indigo-500 hover:to-indigo-200 text-white/90 font-semibold transition duration-200" %>
+      <%= link_to "新規登録", new_dark_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 text-white/90 font-semibold transition duration-200" %>
     </div>
   </div>
 <% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -10,8 +10,10 @@
     <div class="flex gap-3 md:gap-6">
 
       <% if both_times_present?(@dark_time, @light_time) %>
-        <div class="hidden md:flex items-center justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
+        <div class="hidden md:flex flex-col gap-2 items-stretch justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
           <%= link_to "新規登録", new_light_time_path, class: "w-full text-xs text-center text-zinc-800 inline-block py-1 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+
+          <%= link_to "後悔したと思ったら", new_regret_record_path, class: "w-full text-xs leading-tight text-center text-white/90 inline-block py-1.5 rounded-2xl bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200" %>
         </div>
       <% end %>
 
@@ -75,8 +77,10 @@
 
         <!-- スマホ対応画面における新規登録ボタン -->
         <% if both_times_present?(@dark_time, @light_time) %>
-          <div class="md:hidden">
+          <div class="md:hidden flex flex-col items-center gap-3">
             <%= link_to "新規登録", new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+
+            <%= link_to "後悔したと思ったら", new_regret_record_path, class: "text-center text-white/90 inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200" %>
           </div>
         <% end %>
       </div>

--- a/app/views/regret_records/_form.html.erb
+++ b/app/views/regret_records/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with model: regret_record, class: "space-y-8" do |f| %>
+  <%= render "shared/error_messages", object: regret_record %>
+
+  <!-- タイトル -->
+  <div>
+    <%= f.label :title, "タイトル（任意）", class: "block text-lg mb-2" %>
+    <%= f.text_field :title, class: "w-full rounded-lg bg-gray-200 text-zinc-800 border-2 border-gray-700 px-4 py-2 focus:outline-none focus:ring-4 focus:ring-blue-400" %>
+  </div>
+
+  <!-- 後悔した内容 -->
+  <div>
+    <%= f.label :content, "後悔した内容", class: "block text-lg mb-2" %>
+
+    <p class="text-sm leading-relaxed mb-3">
+      「後悔した1日を過ごしてしまったなあ」と思ったときに、その気持ちや出来事を書き残す場所です。
+      何に時間を使い、どう感じたのかを振り返り、「なぜそうなったのか」と原因まで掘り下げてみましょう。
+      アプリを使っていないときの気づきや反省も含め、無理のない範囲で自由に書いて構いません。
+    </p>
+
+    <%= f.text_area :content, rows: 6, class: "w-full rounded-lg bg-gray-200 text-zinc-800 border-2 border-gray-700 px-4 py-2 focus:outline-none focus:ring-4 focus:ring-blue-400" %>
+  </div>
+
+  <!-- ボタン -->
+  <div class="flex justify-center gap-6 pt-6">
+    <%= f.submit "登録する", class: "bg-blue-500 hover:bg-blue-600 px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
+    <%= link_to "キャンセル", regret_records_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+  </div>
+
+<% end %>

--- a/app/views/regret_records/_regret_record.html.erb
+++ b/app/views/regret_records/_regret_record.html.erb
@@ -1,0 +1,20 @@
+<div class="bg-violet-800 text-white/90 rounded-lg shadow hover:shadow-lg transition duration-200 h-full p-4 flex flex-col">
+
+  <!-- 日時 -->
+  <p class="text-sm mb-2">
+    <%= format_datetime(regret_record.created_at) %>
+  </p>
+
+  <!-- タイトル -->
+  <% if regret_record.title.present? %>
+    <h2 class="text-lg font-bold mb-2 wrap-break-word">
+      <%= regret_record.title %>
+    </h2>
+  <% end %>
+
+  <!-- 後悔した内容 -->
+  <p class="text-sm whitespace-pre-wrap wrap-break-word">
+    <%= regret_record.content %>
+  </p>
+
+</div>

--- a/app/views/regret_records/index.html.erb
+++ b/app/views/regret_records/index.html.erb
@@ -1,0 +1,35 @@
+<div class="min-h-screen bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
+
+  <!-- ハンバーガーメニュー -->
+  <%= render "shared/hamburger_menu" %>
+
+  <h1 class="text-2xl font-bold text-center mb-8 pt-10">
+    後悔した1日の記録一覧
+  </h1>
+
+  <!-- 新規投稿への導線 -->
+  <div class="flex justify-center mb-10">
+    <%= link_to "後悔した1日を投稿", new_regret_record_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200 shadow-md" %>
+  </div>
+
+  <% if @regret_records.present? %>
+    <div class="w-80 md:w-full max-w-5xl mx-auto">
+      <!-- 一覧 -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 items-stretch" data-test="regret-records-list">
+        <%= render @regret_records %>
+      </div>
+    </div>
+
+    <!-- ページネーション -->
+    <div class="mt-6 flex justify-center">
+      <%= paginate @regret_records %>
+    </div>
+
+  <% else %>
+    <div class="flex items-center justify-center min-h-[50vh]">
+      <p class="text-lg">
+        後悔した1日の記録がまだありません
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/regret_records/new.html.erb
+++ b/app/views/regret_records/new.html.erb
@@ -1,0 +1,13 @@
+<div class="min-h-screen flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
+
+  <div class="w-full max-w-2xl px-10 py-12">
+
+    <!-- タイトル -->
+    <h2 class="text-center text-2xl md:text-3xl font-semibold mb-10">
+      後悔した1日の記録
+    </h2>
+
+    <%= render "form", regret_record: @regret_record %>
+
+  </div>
+</div>

--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -21,6 +21,7 @@
         <li><%= link_to "マイページ", mypage_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mypage_path) %></li>
         <li><%= link_to "活動記録", activity_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(activity_records_path) %></li>
         <li><%= link_to "マイステータス", mystatus_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mystatus_path) %></li>
+        <li><%= link_to "後悔した1日の記録一覧", regret_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(regret_records_path) %></li>
       </ul>
     </nav>
   </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -6,6 +6,7 @@ ja:
       activity_record: 光の時間の活動記録
       purification_time: 浄化タイマー
       pomodoro_setting: ポモドーロ時間設定
+      regret_record: 後悔した1日の記録
     attributes:
       dark_time:
         behavior: 闇の時間での行動
@@ -37,6 +38,9 @@ ja:
       pomodoro_setting:
         work_duration: 活動時間
         break_duration: 休憩時間
+      regret_record:
+        title: タイトル
+        content: 後悔した内容
   enums:
     purification_time:
       status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,9 @@ Rails.application.routes.draw do
   # ポモドーロタイマーの時間設定
   resource :pomodoro_setting, only: %i[update]
 
+  # 後悔した1日の記録
+  resources :regret_records, only: %i[index new create]
+
   # 使い方ページ
   get "/how_to_use", to: "static_pages#how_to_use", as: "how_to_use"
 

--- a/db/migrate/20260603063444_create_regret_records.rb
+++ b/db/migrate/20260603063444_create_regret_records.rb
@@ -1,0 +1,11 @@
+class CreateRegretRecords < ActiveRecord::Migration[8.1]
+  def change
+    create_table :regret_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :title
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_141310) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_063444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -78,6 +78,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_141310) do
     t.index ["user_id"], name: "index_purification_times_on_user_id", unique: true
   end
 
+  create_table "regret_records", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.text "title"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_regret_records_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -97,4 +106,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_141310) do
   add_foreign_key "light_times", "users"
   add_foreign_key "pomodoro_settings", "users"
   add_foreign_key "purification_times", "users"
+  add_foreign_key "regret_records", "users"
 end

--- a/spec/factories/regret_records.rb
+++ b/spec/factories/regret_records.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :regret_record do
+    title { "ダラダラ過ごしてしまった日" }
+    content { "やるべきことに手をつけられず、一日中スマホを触ってしまった。" }
+
+    association :user
+  end
+end

--- a/spec/models/regret_record_spec.rb
+++ b/spec/models/regret_record_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe RegretRecord, type: :model do
+  describe "アソシエーション" do
+    it "User に属していること" do
+      association = described_class.reflect_on_association(:user)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+
+  describe "バリデーション" do
+    it "factory は有効であること" do
+      expect(build(:regret_record)).to be_valid
+    end
+
+    it "title と content が入力されていれば有効であること" do
+      regret_record = build(:regret_record, title: "後悔した日", content: "やるべきことができなかった")
+      expect(regret_record).to be_valid
+    end
+
+    it "title が空でも content があれば有効であること" do
+      regret_record = build(:regret_record, title: nil)
+      expect(regret_record).to be_valid
+    end
+
+    it "content が nil の場合は無効であること" do
+      regret_record = build(:regret_record, content: nil)
+      expect(regret_record).to be_invalid
+      expect(regret_record.errors[:content]).to be_present
+    end
+
+    it "user が紐付いていない場合は無効であること" do
+      regret_record = build(:regret_record, user: nil)
+      expect(regret_record).to be_invalid
+      expect(regret_record.errors[:user]).to be_present
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe User, type: :model do
         expect(association.options[:dependent]).to eq :destroy
       end
     end
+
+    it "regret_records を dependent: :destroy で複数持つこと" do
+      association = described_class.reflect_on_association(:regret_records)
+      aggregate_failures do
+        expect(association.macro).to eq :has_many
+        expect(association.options[:dependent]).to eq :destroy
+      end
+    end
   end
 
   # =========================================================

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe "RegretRecords", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /regret_records" do
+    it "正常に表示される" do
+      get regret_records_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "自分の記録のみ表示される" do
+      own = create(:regret_record, user: user, content: "自分の後悔")
+      create(:regret_record, user: other_user, content: "他人の後悔")
+
+      get regret_records_path
+
+      aggregate_failures do
+        expect(response.body).to include("自分の後悔")
+        expect(response.body).not_to include("他人の後悔")
+      end
+    end
+  end
+
+  describe "GET /regret_records/new" do
+    it "正常に表示される" do
+      get new_regret_record_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /regret_records" do
+    let(:success_message) do
+      I18n.t("defaults.flash_message.created", item: RegretRecord.model_name.human)
+    end
+
+    let(:failure_message) do
+      I18n.t("defaults.flash_message.not_created", item: RegretRecord.model_name.human)
+    end
+
+    context "正常系" do
+      let(:valid_params) do
+        {
+          regret_record: {
+            title: "後悔した日",
+            content: "やるべきことができなかった"
+          }
+        }
+      end
+
+      it "作成できる" do
+        expect {
+          post regret_records_path, params: valid_params
+        }.to change(user.regret_records, :count).by(1)
+
+        aggregate_failures do
+          expect(response).to redirect_to(regret_records_path)
+          expect(flash[:notice]).to eq(success_message)
+        end
+      end
+    end
+
+    context "異常系" do
+      let(:invalid_params) do
+        {
+          regret_record: {
+            title: "タイトルのみ",
+            content: ""
+          }
+        }
+      end
+
+      it "作成できない" do
+        expect {
+          post regret_records_path, params: invalid_params
+        }.not_to change(RegretRecord, :count)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe "RegretRecords", type: :system do
+  let(:user) { create(:user) }
+  # ハンバーガーメニューはマイページに dark_time と light_time の両方がある時のみ表示される
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "新規作成" do
+    it "新規作成でき、一覧に登録した内容が表示されること" do
+      visit new_regret_record_path
+
+      fill_in "タイトル（任意）", with: "ダラダラした日"
+      fill_in "後悔した内容", with: "やるべきことに手をつけられなかった"
+
+      click_button "登録する"
+
+      aggregate_failures do
+        expect(page).to have_current_path(regret_records_path)
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.created", item: RegretRecord.model_name.human)
+        )
+        expect(page).to have_content("ダラダラした日")
+        expect(page).to have_content("やるべきことに手をつけられなかった")
+      end
+    end
+
+    it "後悔した内容が未入力では作成できないこと" do
+      visit new_regret_record_path
+
+      fill_in "後悔した内容", with: ""
+
+      click_button "登録する"
+
+      aggregate_failures do
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.not_created", item: RegretRecord.model_name.human)
+        )
+        expect(page).to have_current_path(new_regret_record_path)
+      end
+    end
+
+    it "キャンセルで一覧へ戻ること" do
+      visit new_regret_record_path
+
+      click_link "キャンセル"
+
+      expect(page).to have_current_path(regret_records_path)
+    end
+  end
+
+  describe "マイページからの導線" do
+    it "「後悔したと思ったら」をクリックすると新規作成フォームが表示されること" do
+      visit mypage_path
+
+      # PC用・モバイル用で同じ文言のリンクが2つあるため、実際に表示されている方をクリックする
+      # (ignore_hidden_elements = false のため visible: true で可視要素に限定する)
+      click_link "後悔したと思ったら", match: :first, visible: true
+
+      aggregate_failures do
+        expect(page).to have_current_path(new_regret_record_path)
+        expect(page).to have_content("後悔した1日の記録")
+      end
+    end
+  end
+
+  describe "ハンバーガーメニューからの導線" do
+    it "「後悔した1日の記録一覧」をクリックすると一覧画面が表示されること" do
+      visit mypage_path
+
+      find('[data-hamburger-target="button"]').click
+
+      within('[data-hamburger-target="menu"]') do
+        click_on "後悔した1日の記録一覧"
+      end
+
+      aggregate_failures do
+        expect(page).to have_current_path(regret_records_path)
+        expect(page).to have_content("後悔した1日の記録一覧")
+      end
+    end
+  end
+
+  describe "一覧画面からの導線" do
+    it "「後悔した1日を投稿」をクリックすると新規作成フォームが表示されること" do
+      visit regret_records_path
+
+      click_link "後悔した1日を投稿"
+
+      expect(page).to have_current_path(new_regret_record_path)
+    end
+
+    it "記録がない場合は案内文が表示されること" do
+      visit regret_records_path
+
+      expect(page).to have_content("後悔した1日の記録がまだありません")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Closes #136

「後悔した1日を過ごしてしまったなあ」と思ったときに、その気持ちや出来事を書き残せる機能を追加しました。マイページからアクセスでき、`User` に紐づく `RegretRecord`（`title` 任意 / `content` 必須）を新規作成・一覧表示できます。

## 実装内容
- ルーティング設定（`resources :regret_records, only: %i[index new create]`）
- マイグレーション（`regret_records` テーブル：`user` 参照 + `title` / `content`）
- `RegretRecordsController`（`index` / `new` / `create`）
- マイページに「後悔したと思ったら」導線（PC用カード内・モバイル用の両方）
- ハンバーガーメニューに「後悔した1日の記録一覧」導線
- 一覧画面に「後悔した1日を投稿」導線、記録が無い場合の案内文
- 新規登録後は一覧へリダイレクトし、登録内容が表示される

## 設計メモ
- 関連は `User` のみ（`has_many :regret_records, dependent: :destroy`）。`DarkTime` とは関連づけていません。
- `create` は `current_user.regret_records.build` で所有者を束縛し、`user_id` は permit していません。

## テスト
- モデル / リクエスト / システムスペックを追加
- 複数 expect は `aggregate_failures` で集約（既存規約に準拠）
- ローカルで全 464 examples green / RuboCop no offenses 確認済み

## その他
- `.gitignore` に `.claude/`（Claude Code のローカル状態）を追加（本機能とは独立した付随変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)