### PR TITLE
feat: 後悔した1日の記録の詳細画面を追加

### DIFF
--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -1,7 +1,11 @@
 class RegretRecordsController < ApplicationController
+  before_action :set_regret_record, only: %i[show]
+
   def index
     @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page])
   end
+
+  def show; end
 
   def new
     @regret_record = current_user.regret_records.build
@@ -18,6 +22,10 @@ class RegretRecordsController < ApplicationController
   end
 
   private
+
+  def set_regret_record
+    @regret_record = current_user.regret_records.find(params[:id])
+  end
 
   def regret_record_params
     params.require(:regret_record).permit(:title, :content)

--- a/app/views/regret_records/_regret_record.html.erb
+++ b/app/views/regret_records/_regret_record.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-violet-800 text-white/90 rounded-lg shadow hover:shadow-lg transition duration-200 h-full p-4 flex flex-col">
+<%= link_to regret_record_path(regret_record), class: "bg-violet-800 text-white/90 rounded-lg shadow hover:shadow-lg transition duration-200 h-full p-4 flex flex-col" do %>
 
   <!-- 日時 -->
   <p class="text-sm mb-2">
@@ -7,14 +7,14 @@
 
   <!-- タイトル -->
   <% if regret_record.title.present? %>
-    <h2 class="text-lg font-bold mb-2 wrap-break-word">
+    <h2 class="text-lg font-bold mb-2 wrap-break-word line-clamp-2">
       <%= regret_record.title %>
     </h2>
   <% end %>
 
   <!-- 後悔した内容 -->
-  <p class="text-sm whitespace-pre-wrap wrap-break-word">
+  <p class="text-sm whitespace-pre-wrap wrap-break-word line-clamp-3">
     <%= regret_record.content %>
   </p>
 
-</div>
+<% end %>

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -1,0 +1,37 @@
+<div class="min-h-screen bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
+
+  <!-- 戻るボタン -->
+  <%= link_to "← 一覧に戻る", regret_records_path, class: "mt-6 ml-6 mb-10 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+
+  <div class="w-full max-w-2xl px-10 mx-auto pb-20">
+
+    <h1 class="text-2xl font-bold text-center mb-10">
+      後悔した1日の記録詳細
+    </h1>
+
+    <!-- 日時 -->
+    <div class="mb-8">
+      <p class="mb-2 text-sm">記録した日時</p>
+      <div class="bg-violet-800 rounded-lg px-6 py-4">
+        <%= format_datetime(@regret_record.created_at) %>
+      </div>
+    </div>
+
+    <!-- タイトル -->
+    <div class="mb-8">
+      <p class="mb-2 text-sm">タイトル</p>
+      <div class="bg-violet-800 rounded-lg px-6 py-4 wrap-break-word">
+        <%= @regret_record.title.presence || "（未入力）" %>
+      </div>
+    </div>
+
+    <!-- 後悔した内容 -->
+    <div class="mb-8">
+      <p class="mb-2 text-sm">後悔した内容</p>
+      <div class="bg-violet-800 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word">
+        <%= @regret_record.content %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   resource :pomodoro_setting, only: %i[update]
 
   # 後悔した1日の記録
-  resources :regret_records, only: %i[index new create]
+  resources :regret_records, only: %i[index show new create]
 
   # 使い方ページ
   get "/how_to_use", to: "static_pages#how_to_use", as: "how_to_use"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,3 +48,29 @@ dark_time = user.dark_time || user.create_dark_time!(
     light_time: light_time
   )
 end
+
+# RegretRecordを作成（一覧の体裁確認用にバリエーションを持たせる）
+if user.regret_records.empty?
+  # ランダムな通常データ
+  20.times do
+    user.regret_records.create!(
+      title: [ Faker::Lorem.sentence(word_count: rand(2..6)), nil ].sample,
+      content: Faker::Lorem.paragraph(sentence_count: rand(1..8)),
+      created_at: Faker::Time.backward(days: 30)
+    )
+  end
+
+  # レイアウトが崩れやすいエッジケース
+  user.regret_records.create!(
+    title: "とても長いタイトルを入力したときにカードの高さが崩れないか確認するためのダミータイトルです" * 2,
+    content: "短い内容"
+  )
+  user.regret_records.create!(
+    title: nil,
+    content: "タイトル無し・本文のみのパターン。" + Faker::Lorem.paragraph(sentence_count: 10)
+  )
+  user.regret_records.create!(
+    title: "スペースなし長文字列",
+    content: "https://example.com/" + ("a" * 120)
+  )
+end

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe "RegretRecords", type: :request do
     end
   end
 
+  describe "GET /regret_records/:id" do
+    it "自分の記録の詳細が表示される" do
+      regret_record = create(:regret_record, user: user, content: "自分の後悔")
+
+      get regret_record_path(regret_record)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("自分の後悔")
+      end
+    end
+
+    it "他人の記録にアクセスすると 404 を返す" do
+      other_regret_record = create(:regret_record, user: other_user)
+
+      get regret_record_path(other_regret_record)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "POST /regret_records" do
     let(:success_message) do
       I18n.t("defaults.flash_message.created", item: RegretRecord.model_name.human)

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -53,6 +53,35 @@ RSpec.describe "RegretRecords", type: :system do
     end
   end
 
+  describe "詳細画面" do
+    let!(:regret_record) do
+      create(:regret_record, user: user, title: "ダラダラした日", content: "やるべきことに手をつけられなかった")
+    end
+
+    it "一覧の記録をクリックすると詳細画面が表示されること" do
+      visit regret_records_path
+
+      within('[data-test="regret-records-list"]') do
+        click_link "ダラダラした日"
+      end
+
+      aggregate_failures do
+        expect(page).to have_current_path(regret_record_path(regret_record))
+        expect(page).to have_content("後悔した1日の記録詳細")
+        expect(page).to have_content("ダラダラした日")
+        expect(page).to have_content("やるべきことに手をつけられなかった")
+      end
+    end
+
+    it "「一覧に戻る」をクリックすると一覧へ戻ること" do
+      visit regret_record_path(regret_record)
+
+      click_link "← 一覧に戻る"
+
+      expect(page).to have_current_path(regret_records_path)
+    end
+  end
+
   describe "マイページからの導線" do
     it "「後悔したと思ったら」をクリックすると新規作成フォームが表示されること" do
       visit mypage_path


### PR DESCRIPTION
## 概要
Issue #137 対応。「後悔した1日を過ごしてしまったなあと思ったら」機能の**詳細画面**を実装しました。

Closes #137

## 変更内容
### 機能
- `resources :regret_records` に `:show` ルートを追加
- `RegretRecordsController#show` を追加。`current_user.regret_records.find` で取得するため、**他人の記録にアクセスすると 404**
- 詳細画面ビュー（`show.html.erb`）を新規作成（日時 / タイトル / 後悔した内容を全文表示、改行保持）
- 一覧カードを `link_to` でラップしてクリックで詳細へ遷移
- 一覧カードの体裁崩れ防止: タイトル `line-clamp-2` / 内容 `line-clamp-3` で省略表示（全文は詳細画面で確認）

### その他
- 開発用 seed を追加（一覧/詳細の表示確認用に、長いタイトル・タイトル無し・スペースなし長文字列などのエッジケースを含む RegretRecord を生成）

## テスト
- リクエストスペック: 自分の記録は 200 で表示 / 他人の記録は 404
- システムスペック: 一覧カードのクリックで詳細表示 / 「一覧に戻る」で一覧へ戻る
- 全体スイート: 468 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)