### PR TITLE
feat: 後悔した1日の記録一覧の表示件数を9件に設定

### DIFF
--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -2,7 +2,7 @@ class RegretRecordsController < ApplicationController
   before_action :set_regret_record, only: %i[show]
 
   def index
-    @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page])
+    @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page]).per(9)
   end
 
   def show; end

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -114,6 +114,47 @@ RSpec.describe "RegretRecords", type: :system do
     end
   end
 
+  describe "ページネーション" do
+    context "記録が10件以上あるとき" do
+      before do
+        # 10件作成（per_page: 9 を超える件数）
+        10.times { |i| create(:regret_record, user: user, content: "後悔#{i + 1}") }
+        visit regret_records_path
+      end
+
+      it "1ページ目には9件まで表示されること" do
+        within('[data-test="regret-records-list"]') do
+          expect(page).to have_selector("a", count: 9)
+        end
+      end
+
+      it "ページネーションリンクが表示されること" do
+        expect(page).to have_selector('[data-test="pagination"]')
+      end
+
+      it "2ページ目をクリックすると残りのレコードが表示されること" do
+        click_on "2"
+
+        aggregate_failures do
+          expect(page).to have_current_path(regret_records_path, ignore_query: true)
+          # created_at: desc 順なので、最初に作った「後悔1」が2ページ目に来る
+          expect(page).to have_content("後悔1")
+        end
+      end
+    end
+
+    context "記録が9件以下のとき" do
+      before do
+        9.times { create(:regret_record, user: user) }
+        visit regret_records_path
+      end
+
+      it "ページネーションリンクが表示されないこと" do
+        expect(page).not_to have_selector('[data-test="pagination"]')
+      end
+    end
+  end
+
   describe "一覧画面からの導線" do
     it "「後悔した1日を投稿」をクリックすると新規作成フォームが表示されること" do
       visit regret_records_path


### PR DESCRIPTION
## 概要
Issue #182 対応。後悔した1日の記録一覧の1ページあたり表示件数を **9件** に設定しました。

Closes #182

## 背景
一覧は最大3列のグリッド（`grid-cols-1 md:grid-cols-2 lg:grid-cols-3`）です。Kaminari のデフォルト（25件）だと最終行が中途半端になるため、3の倍数の **9件** にして各行を綺麗に埋めます。

## 変更内容
- `RegretRecordsController#index` に `.per(9)` を追加
- ページネーションのシステムスペックを追加（`activity_records` の前例に揃えた構成）
  - 記録が10件以上: 1ページ目は9件表示 / ページネーションリンク表示 / 「2」クリックで残り表示
  - 記録が9件以下: ページネーションリンクが表示されない

## テスト
- `spec/system/regret_records_spec.rb` 13 examples, 0 failures
- RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)