### PR TITLE
feat: 後悔した1日の記録の編集機能を追加

### DIFF
--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -1,11 +1,22 @@
 class RegretRecordsController < ApplicationController
-  before_action :set_regret_record, only: %i[show]
+  before_action :set_regret_record, only: %i[show edit update]
 
   def index
     @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page]).per(9)
   end
 
   def show; end
+
+  def edit; end
+
+  def update
+    if @regret_record.update(regret_record_params)
+      redirect_to @regret_record, notice: t("defaults.flash_message.updated", item: RegretRecord.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: RegretRecord.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   def new
     @regret_record = current_user.regret_records.build

--- a/app/views/regret_records/_form.html.erb
+++ b/app/views/regret_records/_form.html.erb
@@ -22,8 +22,8 @@
 
   <!-- ボタン -->
   <div class="flex justify-center gap-6 pt-6">
-    <%= f.submit "登録する", class: "bg-blue-500 hover:bg-blue-600 px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", regret_records_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+    <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
+    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/regret_records/edit.html.erb
+++ b/app/views/regret_records/edit.html.erb
@@ -4,10 +4,10 @@
 
     <!-- タイトル -->
     <h2 class="text-center text-2xl md:text-3xl font-semibold mb-10">
-      後悔した1日の記録
+      後悔した1日の記録を編集
     </h2>
 
-    <%= render "form", regret_record: @regret_record, button_text: "登録する", button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: regret_records_path %>
+    <%= render "form", regret_record: @regret_record, button_text: "更新する", button_class: "bg-green-700 hover:bg-green-800", cancel_path: regret_record_path(@regret_record) %>
 
   </div>
 </div>

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -33,5 +33,10 @@
       </div>
     </div>
 
+    <!-- 編集ボタン -->
+    <div class="flex justify-center pt-6">
+      <%= link_to "編集", edit_regret_record_path(@regret_record), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+    </div>
+
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   resource :pomodoro_setting, only: %i[update]
 
   # 後悔した1日の記録
-  resources :regret_records, only: %i[index show new create]
+  resources :regret_records, only: %i[index show new create edit update]
 
   # 使い方ページ
   get "/how_to_use", to: "static_pages#how_to_use", as: "how_to_use"

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -55,6 +55,71 @@ RSpec.describe "RegretRecords", type: :request do
     end
   end
 
+  describe "GET /regret_records/:id/edit" do
+    it "自分の記録の編集画面が表示される" do
+      regret_record = create(:regret_record, user: user, content: "編集前の内容")
+
+      get edit_regret_record_path(regret_record)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("編集前の内容")
+      end
+    end
+
+    it "他人の記録の編集画面にアクセスすると 404 を返す" do
+      other_regret_record = create(:regret_record, user: other_user)
+
+      get edit_regret_record_path(other_regret_record)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "PATCH /regret_records/:id" do
+    let(:success_message) do
+      I18n.t("defaults.flash_message.updated", item: RegretRecord.model_name.human)
+    end
+
+    context "正常系" do
+      it "更新でき、詳細画面にリダイレクトされる" do
+        regret_record = create(:regret_record, user: user, content: "編集前の内容")
+
+        patch regret_record_path(regret_record), params: { regret_record: { content: "編集後の内容" } }
+
+        aggregate_failures do
+          expect(response).to redirect_to(regret_record_path(regret_record))
+          expect(flash[:notice]).to eq(success_message)
+          expect(regret_record.reload.content).to eq("編集後の内容")
+        end
+      end
+    end
+
+    context "異常系" do
+      it "内容が空では更新できない" do
+        regret_record = create(:regret_record, user: user, content: "編集前の内容")
+
+        patch regret_record_path(regret_record), params: { regret_record: { content: "" } }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(regret_record.reload.content).to eq("編集前の内容")
+        end
+      end
+    end
+
+    it "他人の記録を更新しようとすると 404 を返す" do
+      other_regret_record = create(:regret_record, user: other_user, content: "他人の内容")
+
+      patch regret_record_path(other_regret_record), params: { regret_record: { content: "改ざん" } }
+
+      aggregate_failures do
+        expect(response).to have_http_status(:not_found)
+        expect(other_regret_record.reload.content).to eq("他人の内容")
+      end
+    end
+  end
+
   describe "POST /regret_records" do
     let(:success_message) do
       I18n.t("defaults.flash_message.created", item: RegretRecord.model_name.human)

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe "RegretRecords", type: :system do
         expect(page).to have_content(
           I18n.t("defaults.flash_message.not_created", item: RegretRecord.model_name.human)
         )
+        expect(page).to have_content("後悔した内容を入力してください")
         expect(page).to have_current_path(new_regret_record_path)
       end
     end
@@ -79,6 +80,56 @@ RSpec.describe "RegretRecords", type: :system do
       click_link "← 一覧に戻る"
 
       expect(page).to have_current_path(regret_records_path)
+    end
+  end
+
+  describe "編集" do
+    let!(:regret_record) do
+      create(:regret_record, user: user, title: "編集前タイトル", content: "編集前の内容")
+    end
+
+    it "詳細画面の「編集する」から更新でき、詳細画面に反映されること" do
+      visit regret_record_path(regret_record)
+
+      click_link "編集"
+      expect(page).to have_current_path(edit_regret_record_path(regret_record))
+
+      fill_in "タイトル（任意）", with: "編集後タイトル"
+      fill_in "後悔した内容", with: "編集後の内容"
+      click_button "更新する"
+
+      aggregate_failures do
+        expect(page).to have_current_path(regret_record_path(regret_record))
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.updated", item: RegretRecord.model_name.human)
+        )
+        expect(page).to have_content("編集後タイトル")
+        expect(page).to have_content("編集後の内容")
+      end
+    end
+
+    it "後悔した内容が未入力では更新できないこと" do
+      visit edit_regret_record_path(regret_record)
+
+      fill_in "後悔した内容", with: ""
+
+      click_button "更新する"
+
+      aggregate_failures do
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.not_updated", item: RegretRecord.model_name.human)
+        )
+        expect(page).to have_content("後悔した内容を入力してください")
+        expect(page).to have_current_path(edit_regret_record_path(regret_record))
+      end
+    end
+
+    it "「キャンセル」をクリックすると詳細画面へ戻ること" do
+      visit edit_regret_record_path(regret_record)
+
+      click_link "キャンセル"
+
+      expect(page).to have_current_path(regret_record_path(regret_record))
     end
   end
 


### PR DESCRIPTION
## 概要
Issue #138 対応。「後悔した1日を過ごしてしまったなあと思ったら」機能の**編集機能**を実装しました。

Closes #138

## 変更内容
### 機能
- `resources :regret_records` に `:edit, :update` ルートを追加
- `RegretRecordsController` に `edit` / `update` アクションを追加。`set_regret_record` を edit/update にも適用し、**他人の記録にアクセス/更新すると 404**
- 編集画面（`edit.html.erb`）を新規作成。`_form` パーシャルを new/edit で共用
- 詳細画面に「編集」ボタンを追加。**更新成功時は詳細画面へ遷移**

### リファクタ（フォーム共用の作法を統一）
- `_form` の submit ラベル・ボタン色・キャンセル先を `button_text` / `button_class` / `cancel_path` で受け取る形に変更し、light_time / dark_time と同一方式に統一
- 詳細画面の編集ボタンも light/dark と同じ「編集」テキスト・緑色に統一

## テスト
- リクエスト: edit（自分 200 / 他人 404）、update（成功→詳細リダイレクト+flash+反映 / 内容空→422 / 他人→404）
- システム: 詳細「編集」→更新→詳細反映 / 更新失敗（フィールドエラー文言+flash+edit に留まる）/ キャンセル→詳細へ
- 失敗系 system spec の粒度を activity_record / light_time に合わせ、フィールドエラー文言の検証を追加（作成失敗側も統一）
- 全体スイート: 480 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)