### PR TITLE
feat: 後悔した1日の記録の削除機能を追加

### DIFF
--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -1,5 +1,5 @@
 class RegretRecordsController < ApplicationController
-  before_action :set_regret_record, only: %i[show edit update]
+  before_action :set_regret_record, only: %i[show edit update destroy]
 
   def index
     @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page]).per(9)
@@ -30,6 +30,11 @@ class RegretRecordsController < ApplicationController
       flash.now[:alert] = t("defaults.flash_message.not_created", item: RegretRecord.model_name.human)
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @regret_record.destroy!
+    redirect_to regret_records_path, notice: t("defaults.flash_message.deleted", item: RegretRecord.model_name.human), status: :see_other
   end
 
   private

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -33,9 +33,10 @@
       </div>
     </div>
 
-    <!-- 編集ボタン -->
-    <div class="flex justify-center pt-6">
+    <!-- 編集・削除ボタン -->
+    <div class="flex justify-center gap-10 text-center pt-6">
       <%= link_to "編集", edit_regret_record_path(@regret_record), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to "削除", regret_record_path(@regret_record), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
     </div>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   resource :pomodoro_setting, only: %i[update]
 
   # 後悔した1日の記録
-  resources :regret_records, only: %i[index show new create edit update]
+  resources :regret_records
 
   # 使い方ページ
   get "/how_to_use", to: "static_pages#how_to_use", as: "how_to_use"

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -173,4 +173,34 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
   end
+
+  describe "DELETE /regret_records/:id" do
+    let(:success_message) do
+      I18n.t("defaults.flash_message.deleted", item: RegretRecord.model_name.human)
+    end
+
+    it "自分の記録を削除でき、一覧にリダイレクトされる" do
+      regret_record = create(:regret_record, user: user)
+
+      expect {
+        delete regret_record_path(regret_record)
+      }.to change(user.regret_records, :count).by(-1)
+
+      aggregate_failures do
+        expect(response).to redirect_to(regret_records_path)
+        expect(flash[:notice]).to eq(success_message)
+      end
+    end
+
+    it "他人の記録を削除しようとすると 404 を返し、削除されない" do
+      other_regret_record = create(:regret_record, user: other_user)
+
+      aggregate_failures do
+        expect {
+          delete regret_record_path(other_regret_record)
+        }.not_to change(RegretRecord, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -133,6 +133,28 @@ RSpec.describe "RegretRecords", type: :system do
     end
   end
 
+  describe "削除" do
+    let!(:regret_record) do
+      create(:regret_record, user: user, title: "削除する記録", content: "削除される内容")
+    end
+
+    it "詳細画面の「削除」をクリックすると一覧へ遷移し、記録が削除されていること" do
+      visit regret_record_path(regret_record)
+
+      accept_confirm do
+        click_link "削除"
+      end
+
+      aggregate_failures do
+        expect(page).to have_current_path(regret_records_path)
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.deleted", item: RegretRecord.model_name.human)
+        )
+        expect(page).not_to have_content("削除する記録")
+      end
+    end
+  end
+
   describe "マイページからの導線" do
     it "「後悔したと思ったら」をクリックすると新規作成フォームが表示されること" do
       visit mypage_path


### PR DESCRIPTION
## 概要
Issue #139 対応。「後悔した1日を過ごしてしまったなあと思ったら」機能の**削除機能**を実装しました。

Closes #139

## 変更内容
- `resources :regret_records` に `:destroy` を追加。全7アクションを使うようになったため `only:` 指定を撤廃（`activity_records` と同じ作法に統一）
- `RegretRecordsController#destroy` を追加。`set_regret_record` を destroy にも適用し**他人の記録は 404**。削除後は一覧へ `status: :see_other` でリダイレクトし `deleted` flash を表示
- 詳細画面に「削除」ボタンを追加（`turbo_method: :delete` + `turbo_confirm: "本当に削除しますか？"`、light_time と同じ赤ボタン・レイアウト）

## テスト
- リクエスト: 自分の記録を削除→一覧リダイレクト+flash+件数 -1 / 他人→404 で削除されない
- システム: 詳細「削除」→ 確認ダイアログ承認 → 一覧へ遷移し記録が消えている
- 全体スイート: 483 examples, 0 failures

## 補足（別 issue 化予定）
2タブで同じ詳細を開き片方で削除後にもう片方で削除すると、本番では `RecordNotFound` → 404 になります（二重削除や 500 は発生せず、データは安全）。より親切な「既に削除されています」メッセージはアプリ全体の 404 ハンドリング方針の話のため、本 PR の範囲外とし別 issue で検討します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)