### PR TITLE
feat: 後悔した1日の記録にお気に入り機能を追加

### DIFF
--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -1,8 +1,9 @@
 class RegretRecordsController < ApplicationController
-  before_action :set_regret_record, only: %i[show edit update destroy]
+  before_action :set_regret_record, only: %i[show edit update destroy favorite]
 
   def index
-    @regret_records = current_user.regret_records.order(created_at: :desc).page(params[:page]).per(9)
+    @q = current_user.regret_records.ransack(params[:q])
+    @regret_records = @q.result.order(created_at: :desc).page(params[:page]).per(9)
   end
 
   def show; end
@@ -35,6 +36,15 @@ class RegretRecordsController < ApplicationController
   def destroy
     @regret_record.destroy!
     redirect_to regret_records_path, notice: t("defaults.flash_message.deleted", item: RegretRecord.model_name.human), status: :see_other
+  end
+
+  def favorite
+    @regret_record.update!(favorited: !@regret_record.favorited)
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to regret_records_path }
+    end
   end
 
   private

--- a/app/models/regret_record.rb
+++ b/app/models/regret_record.rb
@@ -2,4 +2,13 @@ class RegretRecord < ApplicationRecord
   validates :content, presence: true
 
   belongs_to :user
+
+  # 検索可能カラムの登録（お気に入り絞り込み用）
+  def self.ransackable_attributes(auth_object = nil)
+    [ "favorited" ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
 end

--- a/app/views/regret_records/_favorite_filter.html.erb
+++ b/app/views/regret_records/_favorite_filter.html.erb
@@ -1,0 +1,11 @@
+<% favorited_active = q.favorited_eq.to_s == "true" %>
+
+<!-- お気に入り絞り込みタブ -->
+<div class="flex justify-center gap-2 mb-8">
+  <%= link_to "すべて",
+              regret_records_path,
+              class: "px-5 py-2 rounded-full font-bold transition duration-200 #{favorited_active ? 'bg-gray-200 text-gray-600 hover:bg-gray-300' : 'bg-blue-500 text-white/90'}" %>
+  <%= link_to "★ お気に入り",
+              regret_records_path(q: { favorited_eq: true }),
+              class: "px-5 py-2 rounded-full font-bold transition duration-200 #{favorited_active ? 'bg-blue-500 text-white/90' : 'bg-gray-200 text-gray-600 hover:bg-gray-300'}" %>
+</div>

--- a/app/views/regret_records/_regret_record.html.erb
+++ b/app/views/regret_records/_regret_record.html.erb
@@ -1,20 +1,45 @@
-<%= link_to regret_record_path(regret_record), class: "bg-violet-800 text-white/90 rounded-lg shadow hover:shadow-lg transition duration-200 h-full p-4 flex flex-col" do %>
+<%= turbo_frame_tag dom_id(regret_record), class: "block h-full" do %>
+  <div class="bg-violet-800 text-white/90 rounded-lg shadow hover:shadow-lg transition duration-200 h-full flex flex-col">
 
-  <!-- 日時 -->
-  <p class="text-sm mb-2">
-    <%= format_datetime(regret_record.created_at) %>
-  </p>
+    <!-- 日時（左）とお気に入り（右）を同じ行に揃える -->
+    <div class="flex items-center justify-between px-4 pt-4">
+      <p class="text-sm">
+        <%= format_datetime(regret_record.created_at) %>
+      </p>
 
-  <!-- タイトル -->
-  <% if regret_record.title.present? %>
-    <h2 class="text-lg font-bold mb-2 wrap-break-word line-clamp-2">
-      <%= regret_record.title %>
-    </h2>
-  <% end %>
+      <!-- お気に入りトグル -->
+      <%= button_to favorite_regret_record_path(regret_record),
+                    method: :patch,
+                    form: { data: { turbo_frame: dom_id(regret_record) }, class: "shrink-0 leading-none" },
+                    class: "text-2xl leading-none focus:outline-none",
+                    title: regret_record.favorited? ? "お気に入りを解除" : "お気に入りに追加",
+                    aria: { label: regret_record.favorited? ? "お気に入りを解除" : "お気に入りに追加" } do %>
+        <% if regret_record.favorited? %>
+          <span class="text-yellow-300">★</span>
+        <% else %>
+          <span class="text-gray-300">☆</span>
+        <% end %>
+      <% end %>
+    </div>
 
-  <!-- 後悔した内容 -->
-  <p class="text-sm whitespace-pre-wrap wrap-break-word line-clamp-3">
-    <%= regret_record.content %>
-  </p>
+    <!-- 本文（クリックで詳細へ） -->
+    <%= link_to regret_record_path(regret_record),
+                class: "block grow px-4 pb-4 pt-2",
+                data: { turbo_frame: "_top" } do %>
 
+      <!-- タイトル -->
+      <% if regret_record.title.present? %>
+        <h2 class="text-lg font-bold mb-2 wrap-break-word line-clamp-2">
+          <%= regret_record.title %>
+        </h2>
+      <% end %>
+
+      <!-- 後悔した内容 -->
+      <p class="text-sm whitespace-pre-wrap wrap-break-word line-clamp-3">
+        <%= regret_record.content %>
+      </p>
+
+    <% end %>
+
+  </div>
 <% end %>

--- a/app/views/regret_records/favorite.turbo_stream.erb
+++ b/app/views/regret_records/favorite.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace dom_id(@regret_record), partial: "regret_records/regret_record", locals: { regret_record: @regret_record } %>

--- a/app/views/regret_records/index.html.erb
+++ b/app/views/regret_records/index.html.erb
@@ -8,9 +8,12 @@
   </h1>
 
   <!-- 新規投稿への導線 -->
-  <div class="flex justify-center mb-10">
+  <div class="flex justify-center mb-6">
     <%= link_to "後悔した1日を投稿", new_regret_record_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200 shadow-md" %>
   </div>
+
+  <!-- お気に入り絞り込み -->
+  <%= render "favorite_filter", q: @q %>
 
   <% if @regret_records.present? %>
     <div class="w-80 md:w-full max-w-5xl mx-auto">
@@ -28,7 +31,11 @@
   <% else %>
     <div class="flex items-center justify-center min-h-[50vh]">
       <p class="text-lg">
-        後悔した1日の記録がまだありません
+        <% if params.dig(:q, :favorited_eq).to_s == "true" %>
+          お気に入りの記録がありません。★をクリックして追加できます
+        <% else %>
+          後悔した1日の記録がまだありません
+        <% end %>
       </p>
     </div>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,11 @@ Rails.application.routes.draw do
   resource :pomodoro_setting, only: %i[update]
 
   # 後悔した1日の記録
-  resources :regret_records
+  resources :regret_records do
+    member do
+      patch :favorite        # お気に入りトグル
+    end
+  end
 
   # 使い方ページ
   get "/how_to_use", to: "static_pages#how_to_use", as: "how_to_use"

--- a/db/migrate/20260605061430_add_favorited_to_regret_records.rb
+++ b/db/migrate/20260605061430_add_favorited_to_regret_records.rb
@@ -1,0 +1,5 @@
+class AddFavoritedToRegretRecords < ActiveRecord::Migration[8.1]
+  def change
+    add_column :regret_records, :favorited, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_063444) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_05_061430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_063444) do
   create_table "regret_records", force: :cascade do |t|
     t.text "content", null: false
     t.datetime "created_at", null: false
+    t.boolean "favorited", default: false, null: false
     t.text "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/spec/models/regret_record_spec.rb
+++ b/spec/models/regret_record_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe RegretRecord, type: :model do
       expect(regret_record.errors[:user]).to be_present
     end
   end
+
+  describe "ransack の検索可能カラム" do
+    it "検索可能なカラムが favorited のみであること" do
+      expect(described_class.ransackable_attributes).to eq [ "favorited" ]
+    end
+
+    it "検索可能な関連付けが無いこと" do
+      expect(described_class.ransackable_associations).to eq []
+    end
+  end
 end

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -203,4 +203,53 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
   end
+
+  describe "PATCH /regret_records/:id/favorite" do
+    let!(:regret_record) { create(:regret_record, user: user, favorited: false) }
+
+    context "favorited が false のとき" do
+      it "true にトグルされること" do
+        expect {
+          patch favorite_regret_record_path(regret_record)
+        }.to change { regret_record.reload.favorited }.from(false).to(true)
+      end
+
+      it "turbo_stream リクエストで 200 を返すこと" do
+        patch favorite_regret_record_path(regret_record),
+              headers: { "Accept" => "text/vnd.turbo-stream.html" }
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        end
+      end
+
+      it "html リクエストで一覧ページへリダイレクトすること" do
+        patch favorite_regret_record_path(regret_record)
+        expect(response).to redirect_to(regret_records_path)
+      end
+    end
+
+    context "favorited が true のとき" do
+      before { regret_record.update!(favorited: true) }
+
+      it "false にトグルされること" do
+        expect {
+          patch favorite_regret_record_path(regret_record)
+        }.to change { regret_record.reload.favorited }.from(true).to(false)
+      end
+    end
+
+    context "他ユーザーのレコードに対して操作すると" do
+      let!(:other_regret_record) { create(:regret_record, user: other_user, favorited: false) }
+
+      it "更新できず 404 を返すこと" do
+        aggregate_failures do
+          expect {
+            patch favorite_regret_record_path(other_regret_record)
+          }.not_to change { other_regret_record.reload.favorited }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -155,6 +155,83 @@ RSpec.describe "RegretRecords", type: :system do
     end
   end
 
+  describe "お気に入り" do
+    context "お気に入りトグル" do
+      let!(:regret_record) do
+        create(:regret_record, user: user, title: "お気に入り対象", content: "本質的な後悔")
+      end
+
+      it "☆ をクリックすると ★ に切り替わり、レコードが favorited になること" do
+        visit regret_records_path
+
+        within('[data-test="regret-records-list"]') do
+          expect(page).to have_button("お気に入りに追加")
+          click_on "お気に入りに追加"
+          expect(page).to have_button("お気に入りを解除")
+        end
+
+        expect(regret_record.reload.favorited).to be true
+      end
+
+      it "★ をクリックすると ☆ に戻り、favorited が false になること" do
+        regret_record.update!(favorited: true)
+        visit regret_records_path
+
+        within('[data-test="regret-records-list"]') do
+          expect(page).to have_button("お気に入りを解除")
+          click_on "お気に入りを解除"
+          expect(page).to have_button("お気に入りに追加")
+        end
+
+        expect(regret_record.reload.favorited).to be false
+      end
+    end
+
+    context "お気に入りで絞り込みするとき" do
+      before do
+        create(:regret_record, user: user, title: "お気に入り対象", favorited: true)
+        create(:regret_record, user: user, title: "通常レコード", favorited: false)
+      end
+
+      it "「★ お気に入り」タブをクリックするとお気に入りのみ表示されること" do
+        visit regret_records_path
+        click_on "★ お気に入り"
+
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).not_to have_content("通常レコード")
+        end
+      end
+
+      it "「すべて」タブをクリックすると全件表示されること" do
+        visit regret_records_path(q: { favorited_eq: true })
+
+        # まずお気に入りのみ表示されていることを確認
+        expect(page).to have_content("お気に入り対象")
+        expect(page).not_to have_content("通常レコード")
+
+        click_on "すべて"
+
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).to have_content("通常レコード")
+        end
+      end
+    end
+
+    context "お気に入りタブでお気に入りが1件もないとき" do
+      before do
+        create(:regret_record, user: user, favorited: false)
+      end
+
+      it "お気に入り未登録のメッセージが表示されること" do
+        visit regret_records_path
+        click_on "★ お気に入り"
+        expect(page).to have_content("お気に入りの記録がありません。★をクリックして追加できます")
+      end
+    end
+  end
+
   describe "マイページからの導線" do
     it "「後悔したと思ったら」をクリックすると新規作成フォームが表示されること" do
       visit mypage_path


### PR DESCRIPTION
## 概要
「後悔した1日を過ごしてしまったなあと思ったら」の記録に「お気に入り」機能を追加しました。
ユーザーが本質的だと感じた記録を選別でき、一覧でお気に入りのみに絞り込めます。
（将来的に #140 の生成AI要約で、要約対象の入力をお気に入りで絞るための前提機能）

Closes #186

## 変更内容
既存の活動記録（ActivityRecord）のお気に入り機能の作りを踏襲。

- `regret_records` に `favorited`（boolean, default: false, null: false）カラムを追加
- `resources :regret_records` に `member { patch :favorite }` を追加
- `RegretRecordsController#favorite`（トグル、turbo_stream / html 両対応）／index を Ransack 化
- `RegretRecord.ransackable_attributes` に `favorited` を追加
- 一覧カードを★トグル付きに再構成（`turbo_frame` + `button_to`、turbo_stream で★を即時更新）
- 一覧に「すべて / ★お気に入り」絞り込みタブ（`favorited_eq`）と、お気に入り0件時の空状態メッセージを追加

## テスト
`activity_records` のお気に入りテストに準拠し、3層で追加。

- model: ransack 許可リスト（`favorited` のみ／関連なし）
- request: favorited false→true / true→false、turbo_stream 200、html リダイレクト、他人404
- system: トグル両方向、★絞り込み、すべて全件表示、0件空状態

全 495 例パス・RuboCop オフェンスなしを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
