### PR TITLE
fix: Puma の脆弱性対応で 8.0.2 へ更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -618,7 +618,7 @@ CHECKSUMS
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2


### PR DESCRIPTION
## 概要

Puma 7.2.0 に High の脆弱性が2件あるため、修正版へ更新します。本体機能には関係しないセキュリティ対応のみのPRです（1ブランチ＝1関心）。

- CVE-2026-47736 (High)
- CVE-2026-47737 (High)

修正版は `~> 7.2.1` もしくは `>= 8.0.2`。Rails 8 標準の 8.x 系へ揃えるため **8.0.2** へ更新しました。

## 変更内容

- `Gemfile.lock`: puma `7.2.0` → `8.0.2`（`Gemfile` の制約は `>= 5.0` のため変更なし）

## 確認

- `bundler-audit check`: **No vulnerabilities found**
- `bundle exec rspec`: **495 examples, 0 failures**（System Spec は Capybara が puma を使用するため Puma 8 の動作も確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)