### PR TITLE
fix: 詳細画面で自由記述フィールドの改行表示とレイアウトを改善（#192）

### DIFF
--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
+<div class="min-h-screen pb-16 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
 
 <!-- 戻るボタン -->
     <%= link_to "← 活動記録一覧", activity_records_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
@@ -82,9 +82,7 @@
     <!-- コメント -->
     <div class="mb-12">
       <p class="mb-2">コメント</p>
-      <div class="bg-amber-500 rounded-lg px-6 py-4">
-        <%= @activity_record.comment.presence || "なし" %>
-      </div>
+      <div class="bg-amber-500 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word text-left"><%= @activity_record.comment.presence || "なし" %></div>
     </div>
 
     <!-- 編集ボタン -->

--- a/app/views/dark_times/show.html.erb
+++ b/app/views/dark_times/show.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
+<div class="min-h-screen pb-16 bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
 
   <!-- 戻るボタン -->
   <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
@@ -20,17 +20,13 @@
     <!-- 避けたい未来 -->
     <div class="mb-8">
       <p class="mb-2 text-sm">避けたい未来</p>
-      <div class="bg-violet-800 rounded-lg px-6 py-4">
-        <%= @dark_time.unwanted_future.presence || "これから考える" %>
-      </div>
+      <div class="bg-violet-800 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word"><%= @dark_time.unwanted_future.presence || "これから考える" %></div>
     </div>
 
     <!-- 闇の時間の特徴 -->
     <div class="mb-16">
       <p class="mb-2 text-sm">闇の時間の特徴</p>
-      <div class="bg-violet-800 rounded-lg px-6 py-4">
-        <%= @dark_time.characteristic.presence || "これから見つけていく" %>
-      </div>
+      <div class="bg-violet-800 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word"><%= @dark_time.characteristic.presence || "これから見つけていく" %></div>
     </div>
 
     <!-- 編集ボタン -->

--- a/app/views/light_times/show.html.erb
+++ b/app/views/light_times/show.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
+<div class="min-h-screen pb-16 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <!-- 戻るボタン -->
   <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
@@ -19,17 +19,13 @@
     <!-- なりたい自分 -->
     <div class="mb-8">
       <p class="mb-2 text-sm">なりたい自分</p>
-      <div class="bg-amber-500 rounded-lg px-6 py-4">
-        <%= @light_time.desired_self.presence || "まだ見ぬ可能性に満ちた新しい自分に出会うため" %>
-      </div>
+      <div class="bg-amber-500 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word"><%= @light_time.desired_self.presence || "まだ見ぬ可能性に満ちた新しい自分に出会うため" %></div>
     </div>
 
     <!-- 光の時間の特徴 -->
     <div class="mb-12">
       <p class="mb-2 text-sm">光の時間の特徴</p>
-      <div class="bg-amber-500 rounded-lg px-6 py-4">
-        <%= @light_time.characteristic.presence || "これから見つけていく" %>
-      </div>
+      <div class="bg-amber-500 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word"><%= @light_time.characteristic.presence || "これから見つけていく" %></div>
     </div>
 
     <!-- 編集ボタン -->

--- a/app/views/regret_records/_regret_record.html.erb
+++ b/app/views/regret_records/_regret_record.html.erb
@@ -35,9 +35,7 @@
       <% end %>
 
       <!-- 後悔した内容 -->
-      <p class="text-sm whitespace-pre-wrap wrap-break-word line-clamp-3">
-        <%= regret_record.content %>
-      </p>
+      <p class="text-sm whitespace-pre-wrap wrap-break-word line-clamp-3"><%= regret_record.content %></p>
 
     <% end %>
 

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -28,9 +28,7 @@
     <!-- 後悔した内容 -->
     <div class="mb-8">
       <p class="mb-2 text-sm">後悔した内容</p>
-      <div class="bg-violet-800 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word">
-        <%= @regret_record.content %>
-      </div>
+      <div class="bg-violet-800 rounded-lg px-6 py-4 whitespace-pre-wrap wrap-break-word"><%= @regret_record.content %></div>
     </div>
 
     <!-- 編集・削除ボタン -->

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -610,6 +610,14 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
     it "「削除」リンクが表示されること" do
       expect(page).to have_link("削除")
     end
+
+    it "コメントの改行が保持されて表示されること" do
+      activity_record.update!(comment: "コメント1\nコメント2")
+
+      visit activity_record_path(activity_record)
+
+      expect(page).to have_css("div.whitespace-pre-wrap", text: "コメント1")
+    end
   end
 
   # =========================================================

--- a/spec/system/dark_times_spec.rb
+++ b/spec/system/dark_times_spec.rb
@@ -123,6 +123,17 @@ RSpec.describe "DarkTimes", type: :system do
 
       expect(page).to have_current_path(mypage_path)
     end
+
+    it "避けたい未来・特徴の改行が保持されて表示される" do
+      dark_time.update!(unwanted_future: "未来1\n未来2", characteristic: "特徴1\n特徴2")
+
+      visit dark_time_path
+
+      aggregate_failures do
+        expect(page).to have_css("div.whitespace-pre-wrap", text: "未来1")
+        expect(page).to have_css("div.whitespace-pre-wrap", text: "特徴1")
+      end
+    end
   end
 
   describe "DarkTimeが未作成の場合" do

--- a/spec/system/light_times_spec.rb
+++ b/spec/system/light_times_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe "LightTimes", type: :system do
 
         expect(page).to have_current_path(mypage_path)
       end
+
+      it "なりたい自分・特徴の改行が保持されて表示されること" do
+        light_time.update!(desired_self: "自分1\n自分2", characteristic: "特徴1\n特徴2")
+
+        visit light_time_path(light_time)
+
+        aggregate_failures do
+          expect(page).to have_css("div.whitespace-pre-wrap", text: "自分1")
+          expect(page).to have_css("div.whitespace-pre-wrap", text: "特徴1")
+        end
+      end
     end
 
     describe "編集" do


### PR DESCRIPTION
## 概要

issue #192 の対応。`text_area` で複数行入力できるフィールドが、詳細（show）画面では素の出力により**改行が潰れて1行に表示される**問題を修正しました。あわせて、本文が長い場合に編集ボタンが背景の下端からはみ出す現象も修正しています。

## 変更

- **改行の保持**: 自由記述フィールドの表示要素に `whitespace-pre-wrap wrap-break-word` を付与。
- **先頭余白の解消**: `whitespace-pre-wrap` はテンプレートのインデント（字下げ空白）まで描画してしまうため、タグと出力を1行化して先頭の余白を除去。
- **ボタンはみ出しの修正**: 背景ラッパー（`min-h-screen`）に `pb-16` を追加。本文が長いとき、背景下端とコンテンツが近接して編集ボタンが背景外（白）にはみ出す現象を解消。
- **コメントの左寄せ**: 活動記録のコメント表示に `text-left` を追加。

### 対象画面

- `dark_times#show` … characteristic / unwanted_future
- `light_times#show` … characteristic / desired_self
- `activity_records#show` … comment
- `regret_records#show` / `regret_records` 一覧 … content（先頭余白の解消）

## テスト・検証

- `dark_times` / `light_times` / `activity_records` の system spec に、改行を含む内容が `whitespace-pre-wrap` 要素内に表示されることを確認するケースを追加。
- **RSpec**: 527 examples, 0 failures
- **RuboCop**: no offenses

ボタンはみ出しの修正は、長文データで描画したスクリーンショットで再現・解消を確認済みです。

## スコープ外

- 一覧・カードの省略表示（`truncate` / `line-clamp`）の挙動は維持。
- ポモドーロ等の演出系画面は対象外。

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)