### PR TITLE
feat: アカウント編集機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,5 +14,7 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     # 名前を新規登録する場合に必要
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    # 名前をアカウント編集で更新する場合に必要
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,15 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  # Devise の authenticate_user! は devise_controller 内では force: true 無しだと素通りするため、
+  # show を認証必須にするには force: true を明示的に渡す必要がある
+  before_action -> { authenticate_user!(force: true) }, only: [ :show ]
+
+  # GET /users/account
+  # アカウント情報画面
+  def show
+    @user = current_user
+  end
 
   # GET /resource/sign_up
   # def new
@@ -53,6 +62,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # サインアップ後に遷移するパスの指定
   def after_sign_up_path_for(resource)
     root_path
+  end
+
+  # アカウント更新後に遷移するパスの指定（アカウント情報画面へ）
+  def after_update_path_for(resource)
+    user_account_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,9 +1,7 @@
 <div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
 
   <!-- 🔹 ハンバーガーメニュー -->
-  <% if both_times_present?(@dark_time, @light_time) %>
-    <%= render "shared/hamburger_menu" %>
-  <% end %>
+  <%= render "shared/hamburger_menu" %>
 
   <!-- 🔹 右上ユーザーメニュー -->
   <div class="flex justify-end px-6 pt-6">

--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -17,11 +17,15 @@
 
     <!-- ハンバーガーメニュー展開時 -->
     <nav data-hamburger-target="menu" class="fixed top-0 left-0 h-full w-1/2 md:w-1/3 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% z-50 transform -translate-x-full transition-transform duration-300">
+      <% setup_complete = both_times_present?(current_user.dark_time, current_user.light_times.first) %>
       <ul class="pt-35 last:border-b last:border-amber-500">
         <li><%= link_to "マイページ", mypage_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mypage_path) %></li>
-        <li><%= link_to "活動記録", activity_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(activity_records_path) %></li>
-        <li><%= link_to "マイステータス", mystatus_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mystatus_path) %></li>
-        <li><%= link_to "後悔した1日の記録一覧", regret_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(regret_records_path) %></li>
+        <li><%= link_to "アカウント情報", user_account_path, data: { action: "click->hamburger#close" }, class: nav_link_class(user_account_path) %></li>
+        <% if setup_complete %>
+          <li><%= link_to "活動記録", activity_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(activity_records_path) %></li>
+          <li><%= link_to "マイステータス", mystatus_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mystatus_path) %></li>
+          <li><%= link_to "後悔した1日の記録一覧", regret_records_path, data: { action: "click->hamburger#close" }, class: nav_link_class(regret_records_path) %></li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,42 +1,55 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen pb-16">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+  <!-- 戻るボタン -->
+  <%= link_to "← アカウント情報に戻る", user_account_path, class: "mt-6 ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+  <div class="flex items-center justify-center px-6 mt-10">
+    <div class="w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
+
+      <h2 class="text-center text-2xl font-bold mb-6">アカウント編集</h2>
+
+      <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, class: "space-y-4") do |f| %>
+        <%= render "users/shared/error_messages", resource: resource %>
+
+        <!-- 名前 -->
+        <div>
+          <%= f.label :name, "名前", class: "block text-sm font-medium mb-1" %>
+          <%= f.text_field :name, class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+        </div>
+
+        <!-- メールアドレス -->
+        <div>
+          <%= f.label :email, "メールアドレス", class: "block text-sm font-medium mb-1" %>
+          <%= f.email_field :email, autocomplete: "email", class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+        </div>
+
+        <!-- 新しいパスワード -->
+        <div>
+          <%= f.label :password, "パスワード", class: "block text-sm font-medium mb-1" %>
+          <p class="text-xs text-zinc-600 mb-1">変更しない場合は空欄のままにしてください</p>
+          <%= f.password_field :password, autocomplete: "new-password", class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+        </div>
+
+        <!-- パスワード確認 -->
+        <div>
+          <%= f.label :password_confirmation, "パスワード確認", class: "block text-sm font-medium mb-1" %>
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+        </div>
+
+        <!-- 現在のパスワード -->
+        <div>
+          <%= f.label :current_password, "現在のパスワード", class: "block text-sm font-medium mb-1" %>
+          <p class="text-xs text-zinc-600 mb-1">変更を確定するには現在のパスワードの入力が必要です</p>
+          <%= f.password_field :current_password, autocomplete: "current-password", class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+        </div>
+
+        <!-- 更新ボタン -->
+        <div class="flex justify-center gap-4 pt-2">
+          <%= f.submit "更新する", class: "px-6 py-2 rounded-full bg-green-700 text-white/90 font-semibold hover:bg-green-800 transition duration-200 shadow-md" %>
+          <%= link_to "キャンセル", user_account_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+        </div>
+      <% end %>
+
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i></p>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-    <% if @minimum_password_length %>
-      <p><em><%= @minimum_password_length %> characters minimum</em></p>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i></p>
-    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/users/registrations/show.html.erb
+++ b/app/views/users/registrations/show.html.erb
@@ -1,0 +1,34 @@
+<div class="bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen pb-16">
+
+  <!-- 戻るボタン -->
+  <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+
+  <div class="flex items-center justify-center px-6 mt-10">
+    <div class="w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">
+
+      <h2 class="text-center text-2xl font-bold mb-8">アカウント情報</h2>
+
+      <!-- 名前 -->
+      <div class="mb-6">
+        <p class="text-sm font-medium mb-1">名前</p>
+        <div class="bg-gray-200 rounded-md border border-gray-400 px-3 py-2 wrap-break-word">
+          <%= @user.name %>
+        </div>
+      </div>
+
+      <!-- メールアドレス -->
+      <div class="mb-8">
+        <p class="text-sm font-medium mb-1">メールアドレス</p>
+        <div class="bg-gray-200 rounded-md border border-gray-400 px-3 py-2 wrap-break-word">
+          <%= @user.email %>
+        </div>
+      </div>
+
+      <!-- 編集ボタン -->
+      <div class="text-center">
+        <%= link_to "編集する", edit_user_registration_path, class: "inline-block bg-green-700 hover:bg-green-800 px-6 py-2 rounded-full text-white/90 font-semibold transition duration-200 shadow-md" %>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
+
+  # アカウント情報画面
+  devise_scope :user do
+    get "users/account", to: "users/registrations#show", as: :user_account
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe "User Registrations", type: :request do
   describe "POST /users" do
     context "正常系" do
       it "ユーザーが登録できる" do
-        expect {
-          post user_registration_path, params: {
-            user: {
-              name: "山田太郎",
-              email: "new@example.com",
-              password: "password123",
-              password_confirmation: "password123"
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: "山田太郎",
+                email: "new@example.com",
+                password: "password123",
+                password_confirmation: "password123"
+              }
             }
-          }
-        }.to change(User, :count).by(1)
+          }.to change(User, :count).by(1)
 
-        expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(root_path)
+        end
       end
 
       it "nameが30文字なら登録できる" do
@@ -36,65 +38,197 @@ RSpec.describe "User Registrations", type: :request do
 
     context "異常系" do
       it "登録失敗する（emailなし）" do
-        expect {
-          post user_registration_path, params: {
-            user: {
-              name: "山田太郎",
-              email: "",
-              password: "password123",
-              password_confirmation: "password123"
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: "山田太郎",
+                email: "",
+                password: "password123",
+                password_confirmation: "password123"
+              }
             }
-          }
-        }.not_to change(User, :count)
+          }.not_to change(User, :count)
 
-        expect(response.body).to include("メールアドレスを入力してください")
+          expect(response.body).to include("メールアドレスを入力してください")
+        end
       end
 
       it "nameがないと登録できない" do
-        expect {
-          post user_registration_path, params: {
-            user: {
-              name: "",
-              email: "new@example.com",
-              password: "password123",
-              password_confirmation: "password123"
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: "",
+                email: "new@example.com",
+                password: "password123",
+                password_confirmation: "password123"
+              }
             }
-          }
-        }.not_to change(User, :count)
+          }.not_to change(User, :count)
 
-        expect(response.body).to include("名前を入力してください")
+          expect(response.body).to include("名前を入力してください")
+        end
       end
 
       it "nameが31文字以上だと登録できない" do
         long_name = "a" * 31
 
-        expect {
-          post user_registration_path, params: {
-            user: {
-              name: long_name,
-              email: "new@example.com",
-              password: "password123",
-              password_confirmation: "password123"
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: long_name,
+                email: "new@example.com",
+                password: "password123",
+                password_confirmation: "password123"
+              }
             }
-          }
-        }.not_to change(User, :count)
+          }.not_to change(User, :count)
 
-        expect(response.body).to include("名前は30文字以内で入力してください")
+          expect(response.body).to include("名前は30文字以内で入力してください")
+        end
       end
 
       it "パスワードに空白が含まれていると登録できない" do
-        expect {
-          post user_registration_path, params: {
-            user: {
-              name: "山田太郎",
-              email: "new@example.com",
-              password: "pass word123",
-              password_confirmation: "pass word123"
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: "山田太郎",
+                email: "new@example.com",
+                password: "pass word123",
+                password_confirmation: "pass word123"
+              }
             }
-          }
-        }.not_to change(User, :count)
+          }.not_to change(User, :count)
 
-        expect(response.body).to include("パスワードにスペースを含めることはできません")
+          expect(response.body).to include("パスワードにスペースを含めることはできません")
+        end
+      end
+    end
+  end
+
+  describe "GET /users/account" do
+    context "ログイン済みの場合" do
+      let(:user) { create(:user, name: "元の名前", email: "original@example.com") }
+
+      before { sign_in user }
+
+      it "アカウント情報画面が表示される" do
+        get user_account_path
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("元の名前")
+          expect(response.body).to include("original@example.com")
+        end
+      end
+    end
+
+    context "未ログインの場合" do
+      it "ログイン画面にリダイレクトされる" do
+        get user_account_path
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "PATCH /users" do
+    let(:user) { create(:user, name: "元の名前", email: "original@example.com", password: "password123", password_confirmation: "password123") }
+
+    before { sign_in user }
+
+    context "正常系" do
+      it "現在のパスワードを入力すると名前を更新でき、アカウント情報画面にリダイレクトされる" do
+        patch user_registration_path, params: {
+          user: {
+            name: "新しい名前",
+            current_password: "password123"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to redirect_to(user_account_path)
+          expect(flash[:notice]).to eq(I18n.t("devise.registrations.updated"))
+          expect(user.reload.name).to eq("新しい名前")
+        end
+      end
+
+      it "現在のパスワードを入力するとメールアドレスを更新できる" do
+        patch user_registration_path, params: {
+          user: {
+            email: "updated@example.com",
+            current_password: "password123"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to redirect_to(user_account_path)
+          expect(user.reload.email).to eq("updated@example.com")
+        end
+      end
+
+      it "現在のパスワードを入力すると新しいパスワードに変更でき、新パスワードでログインできる" do
+        patch user_registration_path, params: {
+          user: {
+            password: "newpassword123",
+            password_confirmation: "newpassword123",
+            current_password: "password123"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to redirect_to(user_account_path)
+          expect(user.reload.valid_password?("newpassword123")).to be true
+        end
+      end
+    end
+
+    context "異常系" do
+      it "現在のパスワードがないと更新できない" do
+        patch user_registration_path, params: {
+          user: {
+            name: "新しい名前"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("現在のパスワードを入力してください")
+          expect(user.reload.name).to eq("元の名前")
+        end
+      end
+
+      it "現在のパスワードが誤っていると更新できない" do
+        patch user_registration_path, params: {
+          user: {
+            name: "新しい名前",
+            current_password: "wrongpassword"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("現在のパスワードは不正な値です")
+          expect(user.reload.name).to eq("元の名前")
+        end
+      end
+
+      it "nameを空にすると更新できない" do
+        patch user_registration_path, params: {
+          user: {
+            name: "",
+            current_password: "password123"
+          }
+        }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("名前を入力してください")
+          expect(user.reload.name).to eq("元の名前")
+        end
       end
     end
   end

--- a/spec/system/account_spec.rb
+++ b/spec/system/account_spec.rb
@@ -1,0 +1,211 @@
+require "rails_helper"
+
+RSpec.describe "Account", type: :system do
+  let(:user) { create(:user, name: "元の名前", email: "original@example.com", password: "password123", password_confirmation: "password123") }
+  # マイページ右上のユーザー名カード（導線）は dark_time と light_time の両方がある時のみ表示される
+  let!(:light_time) { create(:light_time, :current, user: user) }
+  let!(:dark_time)  { create(:dark_time, user: user) }
+
+  before do
+    sign_in user
+  end
+
+  describe "アカウント情報画面への導線" do
+    it "ハンバーガーメニューの「アカウント情報」からアカウント情報画面へ遷移する" do
+      visit mypage_path
+
+      find('[data-hamburger-target="button"]').click
+      within('[data-hamburger-target="menu"]') do
+        click_on "アカウント情報"
+      end
+
+      aggregate_failures do
+        expect(page).to have_current_path(user_account_path)
+        expect(page).to have_content("元の名前")
+        expect(page).to have_content("original@example.com")
+      end
+    end
+  end
+
+  describe "アカウント情報表示" do
+    it "名前とメールアドレスが表示される" do
+      visit user_account_path
+
+      aggregate_failures do
+        expect(page).to have_content("元の名前")
+        expect(page).to have_content("original@example.com")
+        expect(page).to have_link("編集する")
+      end
+    end
+
+    it "マイページへ戻れる" do
+      visit user_account_path
+
+      click_link "← マイページに戻る"
+
+      expect(page).to have_current_path(mypage_path)
+    end
+  end
+
+  describe "光・闇いずれかが未登録の場合のハンバーガーメニュー" do
+    # 光・闇の時間を持たないユーザーでログインし直す
+    let(:incomplete_user) { create(:user) }
+
+    before do
+      sign_out user
+      sign_in incomplete_user
+      visit mypage_path
+      find('[data-hamburger-target="button"]').click
+    end
+
+    it "マイページとアカウント情報のみ表示される" do
+      within('[data-hamburger-target="menu"]') do
+        aggregate_failures do
+          expect(page).to have_link("マイページ")
+          expect(page).to have_link("アカウント情報")
+          expect(page).not_to have_link("活動記録")
+          expect(page).not_to have_link("マイステータス")
+          expect(page).not_to have_link("後悔した1日の記録一覧")
+        end
+      end
+    end
+
+    it "アカウント情報へ遷移できる" do
+      within('[data-hamburger-target="menu"]') do
+        click_on "アカウント情報"
+      end
+
+      expect(page).to have_current_path(user_account_path)
+    end
+  end
+
+  describe "光・闇の両方が登録済みの場合のハンバーガーメニュー" do
+    before do
+      visit mypage_path
+      find('[data-hamburger-target="button"]').click
+    end
+
+    it "全メニュー項目とアカウント情報が表示される" do
+      within('[data-hamburger-target="menu"]') do
+        aggregate_failures do
+          expect(page).to have_link("マイページ")
+          expect(page).to have_link("活動記録")
+          expect(page).to have_link("マイステータス")
+          expect(page).to have_link("後悔した1日の記録一覧")
+          expect(page).to have_link("アカウント情報")
+        end
+      end
+    end
+  end
+
+  describe "未ログインの場合" do
+    it "アカウント情報画面はログイン画面にリダイレクトされる" do
+      sign_out user
+      visit user_account_path
+
+      expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+
+  describe "アカウント編集" do
+    context "正常系" do
+      it "現在のパスワードを入力して名前を更新するとアカウント情報画面へ遷移し、更新される" do
+        visit user_account_path
+        click_link "編集する"
+
+        expect(page).to have_current_path(edit_user_registration_path)
+
+        fill_in "名前", with: "新しい名前"
+        fill_in "現在のパスワード", with: "password123"
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(user_account_path)
+          expect(page).to have_content(I18n.t("devise.registrations.updated"))
+          expect(page).to have_content("新しい名前")
+          expect(user.reload.name).to eq("新しい名前")
+        end
+      end
+
+      it "現在のパスワードを入力してメールアドレスを更新できる" do
+        visit edit_user_registration_path
+
+        fill_in "メールアドレス", with: "updated@example.com"
+        fill_in "現在のパスワード", with: "password123"
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(user_account_path)
+          expect(page).to have_content("updated@example.com")
+          expect(user.reload.email).to eq("updated@example.com")
+        end
+      end
+
+      it "現在のパスワードを入力して新しいパスワードに変更できる" do
+        visit edit_user_registration_path
+
+        fill_in "パスワード", with: "newpassword123", exact: true
+        fill_in "パスワード確認", with: "newpassword123"
+        fill_in "現在のパスワード", with: "password123"
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(user_account_path)
+          expect(user.reload.valid_password?("newpassword123")).to be true
+        end
+      end
+
+      it "キャンセルするとアカウント情報画面へ戻る" do
+        visit edit_user_registration_path
+
+        click_link "キャンセル"
+
+        expect(page).to have_current_path(user_account_path)
+      end
+    end
+
+    context "異常系" do
+      it "現在のパスワードが未入力の場合は更新できない" do
+        visit edit_user_registration_path
+
+        fill_in "名前", with: "新しい名前"
+        # 現在のパスワードを入力しない
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(edit_user_registration_path)
+          expect(page).to have_content("現在のパスワードを入力してください")
+          expect(user.reload.name).to eq("元の名前")
+        end
+      end
+
+      it "現在のパスワードが誤っている場合は更新できない" do
+        visit edit_user_registration_path
+
+        fill_in "名前", with: "新しい名前"
+        fill_in "現在のパスワード", with: "wrongpassword"
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(edit_user_registration_path)
+          expect(page).to have_content("現在のパスワードは不正な値です")
+          expect(user.reload.name).to eq("元の名前")
+        end
+      end
+
+      it "名前を空にすると更新できない" do
+        visit edit_user_registration_path
+
+        fill_in "名前", with: ""
+        fill_in "現在のパスワード", with: "password123"
+        click_button "更新する"
+
+        aggregate_failures do
+          expect(page).to have_current_path(edit_user_registration_path)
+          expect(page).to have_content("名前を入力してください")
+          expect(user.reload.name).to eq("元の名前")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

issue #141 に基づき、アカウント情報の閲覧・編集機能を追加しました。

Closes #141

## 変更内容

- `GET /users/account`（`user_account`）でアカウント情報画面を表示
- `Users::RegistrationsController` に `show` / `after_update_path_for` を追加
  - `show` は `authenticate_user!(force: true)` で認証必須化（Devise の `authenticate_user!` は devise_controller 内では `force` なしだと素通りするため）
  - 更新後はアカウント情報画面（`user_account_path`）へ遷移
- `account_update` で `name` を許可
- アカウント情報画面・編集画面のビューを追加・整備
- ハンバーガーメニューにアカウント情報リンクを追加し、常時表示に変更
  - 光・闇いずれか未登録時は「マイページ」「アカウント情報」のみ表示
  - 両方登録済みのときは全メニュー項目を表示

## テスト

- リクエストスペック（`spec/requests/users/registrations_spec.rb`）: アカウント情報表示・更新（名前／メール／パスワード）・認証・各異常系
- システムスペック（`spec/system/account_spec.rb`）: 導線・表示・編集・キャンセル・メニュー表示分岐・未ログインリダイレクト

いずれもグリーン、RuboCop 違反なしを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)