### PR TITLE
fix: 本番のホスト設定を独自ドメインに対応させる

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)
@@ -545,7 +545,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "get-the-time.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {
@@ -80,11 +80,12 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "get-the-time.com",            # 本番ドメイン
+    "www.get-the-time.com",        # www サブドメイン
+    "get-the-time.onrender.com"    # Render のデフォルトドメイン（フォールバック用）
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要

独自ドメイン `get-the-time.com` の取得・Render/DNS 設定が完了したため、コード側の本番ホスト設定を対応させます。

Refs #145

## 変更内容

### 1. 本番ホスト設定（`config/environments/production.rb`）

- **メーラーのデフォルト URL ホスト** を `example.com` → `get-the-time.com` に変更
  - Devise の `:recoverable`（パスワードリセット）が有効なため、メール内リンクが正しいドメインを指すようにする
- **`config.hosts` を有効化**し、以下3ホストを許可（DNS リバインディング / Host ヘッダ攻撃対策）
  - `get-the-time.com`（本番ドメイン）
  - `www.get-the-time.com`（www サブドメイン）
  - `get-the-time.onrender.com`（Render デフォルトドメイン／フォールバック用）
- **`config.host_authorization`** でヘルスチェックパス `/up` を認可対象外に設定
  - Render のヘルスチェックが Host 認可でブロックされ、デプロイ失敗・再起動ループに陥るのを防止

### 2. brakeman を 8.0.5 に更新（`Gemfile.lock`）

- `bin/brakeman` が付与する `--ensure-latest` により、インストール済みの 8.0.4 が最新でないと CI(`scan_ruby`) が exit code 5 で失敗していたため、最新版へ更新
- ローカル（Docker）で `bin/brakeman --no-pager` を実行し、exit code 0 / 警告 0 件を確認済み

## デプロイ後の確認ポイント

`config.hosts` を有効化したため、本番反映後に以下を確認してください。

- [x] `https://get-the-time.com/` でログイン〜画面遷移ができる（403 Blocked host が出ない）
- [x] Render のデプロイがヘルスチェックで失敗せず Live になる
- [x] 必要なら `www.` / `onrender.com` 経由のアクセスも確認

## 補足（本 PR の対象外）

パスワードリセット機能の本実装に必要な **SMTP 設定**（`smtp_settings`）と **`mailer_sender`**（`config/initializers/devise.rb`）は、メール送信サービスの選定後に別 PR で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)