### PR TITLE
i18n: フォームラベルと繰り返しボタンを i18n 化

### DIFF
--- a/app/helpers/activity_records_helper.rb
+++ b/app/helpers/activity_records_helper.rb
@@ -48,7 +48,9 @@ module ActivityRecordsHelper
     text.length > 10 ? "#{text.first(10)}..." : text
   end
 
-  def rating_field(form, field, label, left_label:, right_label:)
+  def rating_field(form, field, left_label:, right_label:)
+    label = form.object.class.human_attribute_name(field)
+
     content_tag(:div, class: "mb-6") do
       concat content_tag(:p, label, class: "mb-2 font-semibold")
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,15 @@
 module ApplicationHelper
+  # 任意入力フィールドのラベル接尾辞
+  OPTIONAL_LABEL_SUFFIX = "（任意）"
+
+  # 「（任意）」付きのフォームラベルを生成する。
+  # ラベル名は i18n（activerecord/activemodel の attributes）から引くため、
+  # 属性名そのものはクリーンに保たれ、エラーメッセージには「（任意）」が混入しない。
+  def optional_label(form, attribute, **options)
+    label_text = "#{form.object.class.human_attribute_name(attribute)}#{OPTIONAL_LABEL_SUFFIX}"
+    form.label(attribute, label_text, **options)
+  end
+
   def format_datetime(dt)
     dt&.in_time_zone("Tokyo")&.strftime("%Y-%m-%d %H:%M")
   end

--- a/app/views/activity_records/_search_form.html.erb
+++ b/app/views/activity_records/_search_form.html.erb
@@ -3,10 +3,10 @@
 
 <!-- お気に入り絞り込みタブ -->
 <div class="flex gap-2 mb-3">
-  <%= link_to "すべて",
+  <%= link_to t("shared.buttons.all"),
               url_for(q: { comment_or_light_time_action_cont: keyword }),
               class: "px-4 py-2 rounded-t-lg font-bold transition duration-200 #{favorited_active ? 'bg-gray-200 text-gray-600 hover:bg-gray-300' : 'bg-blue-500 text-white/90'}" %>
-  <%= link_to "★ お気に入り",
+  <%= link_to t("shared.buttons.favorite"),
               url_for(q: { comment_or_light_time_action_cont: keyword, favorited_eq: true }),
               class: "px-4 py-2 rounded-t-lg font-bold transition duration-200 #{favorited_active ? 'bg-blue-500 text-white/90' : 'bg-gray-200 text-gray-600 hover:bg-gray-300'}" %>
 </div>

--- a/app/views/activity_records/edit.html.erb
+++ b/app/views/activity_records/edit.html.erb
@@ -29,7 +29,7 @@
 
       <!-- やること -->
       <div class="mb-4">
-        <%= f.label :task, "やること（任意）", class: "text-sm" %>
+        <%= optional_label f, :task, class: "text-sm" %>
         <%= f.text_field :task, class: "w-full mt-1 p-2 border rounded bg-gray-200" %>
       </div>
 
@@ -46,22 +46,22 @@
       </div>
 
       <!-- 評価 -->
-      <%= rating_field(f, :satisfaction, "満足度", left_label: "不満", right_label: "満足") %>
-      <%= rating_field(f, :progress, "進行度", left_label: "あまり進まなかった", right_label: "思ったより進んだ") %>
-      <%= rating_field(f, :quality, "作業の質", left_label: "理解の深掘りが進まなかった", right_label: "理解を深めることができた") %>
-      <%= rating_field(f, :focus, "集中度", left_label: "集中できなかった", right_label: "集中できた") %>
-      <%= rating_field(f, :fatigue, "疲労感", left_label: "元気", right_label: "疲れている") %>
+      <%= rating_field(f, :satisfaction, left_label: "不満", right_label: "満足") %>
+      <%= rating_field(f, :progress, left_label: "あまり進まなかった", right_label: "思ったより進んだ") %>
+      <%= rating_field(f, :quality, left_label: "理解の深掘りが進まなかった", right_label: "理解を深めることができた") %>
+      <%= rating_field(f, :focus, left_label: "集中できなかった", right_label: "集中できた") %>
+      <%= rating_field(f, :fatigue, left_label: "元気", right_label: "疲れている") %>
 
       <!-- コメント -->
       <div class="mt-6">
-        <label class="text-sm">コメント（任意）</label>
+        <%= optional_label f, :comment, class: "text-sm" %>
         <%= f.text_area :comment, class: "w-full mt-1 p-2 border rounded bg-gray-200" %>
       </div>
 
       <!-- ボタン -->
       <div class="flex justify-center gap-6 mt-10">
-        <%= f.submit "更新する", class: "bg-green-700 hover:bg-green-800 text-white/90 px-6 py-2 rounded-full transition duration-200" %>
-        <%= link_to "キャンセル", activity_record_path(@activity_record), class: "bg-red-500 hover:bg-red-600 text-white/90 px-6 py-2 rounded-full transition duration-200" %>
+        <%= f.submit t("shared.buttons.update"), class: "bg-green-700 hover:bg-green-800 text-white/90 px-6 py-2 rounded-full transition duration-200" %>
+        <%= link_to t("shared.buttons.cancel"), activity_record_path(@activity_record), class: "bg-red-500 hover:bg-red-600 text-white/90 px-6 py-2 rounded-full transition duration-200" %>
       </div>
 
     <% end %>

--- a/app/views/activity_records/new.html.erb
+++ b/app/views/activity_records/new.html.erb
@@ -29,7 +29,7 @@
 
       <!-- やること -->
       <div class="mb-4">
-        <%= f.label :task, "やること（任意）", class: "text-sm" %>
+        <%= optional_label f, :task, class: "text-sm" %>
         <%= f.text_field :task, class: "w-full mt-1 p-2 border rounded bg-gray-200" %>
       </div>
 
@@ -46,15 +46,15 @@
       </div>
 
       <!-- 評価 -->
-      <%= rating_field(f, :satisfaction, "満足度", left_label: "不満", right_label: "満足") %>
-      <%= rating_field(f, :progress, "進行度", left_label: "あまり進まなかった", right_label: "思ったより進んだ") %>
-      <%= rating_field(f, :quality, "作業の質", left_label: "理解の深掘りが進まなかった", right_label: "理解を深めることができた") %>
-      <%= rating_field(f, :focus, "集中度", left_label: "集中できなかった", right_label: "集中できた") %>
-      <%= rating_field(f, :fatigue, "疲労感", left_label: "元気", right_label: "疲れている") %>
+      <%= rating_field(f, :satisfaction, left_label: "不満", right_label: "満足") %>
+      <%= rating_field(f, :progress, left_label: "あまり進まなかった", right_label: "思ったより進んだ") %>
+      <%= rating_field(f, :quality, left_label: "理解の深掘りが進まなかった", right_label: "理解を深めることができた") %>
+      <%= rating_field(f, :focus, left_label: "集中できなかった", right_label: "集中できた") %>
+      <%= rating_field(f, :fatigue, left_label: "元気", right_label: "疲れている") %>
 
       <!-- コメント -->
       <div class="mt-6">
-        <label class="text-sm">コメント（任意）</label>
+        <%= optional_label f, :comment, class: "text-sm" %>
         <%= f.text_area :comment, class: "w-full mt-1 p-2 border rounded bg-gray-200" %>
       </div>
 

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -87,8 +87,8 @@
 
     <!-- 編集ボタン -->
     <div class="flex justify-center gap-10">
-      <%= link_to "編集", edit_activity_record_path(@activity_record), class: "bg-green-700 hover:bg-green-800 px-6 py-2 rounded-full text-white/90 font-semibold transition duration-200" %>
-      <%= link_to "削除", activity_record_path(@activity_record), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-2 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.edit"), edit_activity_record_path(@activity_record), class: "bg-green-700 hover:bg-green-800 px-6 py-2 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.destroy"), activity_record_path(@activity_record), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-2 rounded-full text-white/90 font-semibold transition duration-200" %>
     </div>
 
   </div>

--- a/app/views/dark_times/_form.html.erb
+++ b/app/views/dark_times/_form.html.erb
@@ -3,13 +3,13 @@
 
   <!-- 闇の時間での行動 -->
   <div>
-    <%= f.label :behavior, "闇の時間での行動", class: "block text-white/90 text-lg mb-2" %>
+    <%= f.label :behavior, class: "block text-white/90 text-lg mb-2" %>
     <%= f.text_field :behavior, class: "w-full rounded-lg bg-gray-200 border-2 border-black px-4 py-2 focus:outline-none focus:ring-4 focus:ring-purple-300 text-zinc-800" %>
   </div>
 
   <!-- 避けたい未来 -->
   <div>
-    <%= f.label :unwanted_future, "避けたい未来（任意）", class: "block text-white/90 text-lg mb-2" %>
+    <%= optional_label f, :unwanted_future, class: "block text-white/90 text-lg mb-2" %>
 
     <p class="text-sm text-white/90 leading-relaxed mb-3">
       闇の時間での行動を習慣的にやり続けることで待っている絶望の未来とは？
@@ -20,7 +20,7 @@
 
   <!-- 闇の時間の特徴 -->
   <div>
-    <%= f.label :characteristic, "闇の時間の特徴（任意）", class: "block text-white/90 text-lg mb-2" %>
+    <%= optional_label f, :characteristic, class: "block text-white/90 text-lg mb-2" %>
 
     <p class="text-sm text-white/90 leading-relaxed mb-3">
       望んでいないのについやってしまう行動をしている前後や最中に、
@@ -40,7 +40,7 @@
   <!-- ボタン -->
   <div class="flex justify-center gap-6 pt-6">
     <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+    <%= link_to t("shared.buttons.cancel"), cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/dark_times/edit.html.erb
+++ b/app/views/dark_times/edit.html.erb
@@ -7,7 +7,7 @@
       闇の時間での活動内容編集
     </h2>
 
-    <%= render "form", dark_time: @dark_time, button_text: "更新する", button_class: "bg-green-700 hover:bg-green-800", cancel_path: dark_time_path %>
+    <%= render "form", dark_time: @dark_time, button_text: t("shared.buttons.update"), button_class: "bg-green-700 hover:bg-green-800", cancel_path: dark_time_path %>
 
   </div>
 </div>

--- a/app/views/dark_times/new.html.erb
+++ b/app/views/dark_times/new.html.erb
@@ -7,7 +7,7 @@
       闇の時間での活動内容登録
     </h2>
 
-    <%= render "form", dark_time: @dark_time, button_text: "登録する", button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: mypage_path %>
+    <%= render "form", dark_time: @dark_time, button_text: t("shared.buttons.create"), button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: mypage_path %>
 
   </div>
 </div>

--- a/app/views/dark_times/show.html.erb
+++ b/app/views/dark_times/show.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen pb-16 bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
 
   <!-- 戻るボタン -->
-  <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+  <%= link_to "← #{t("shared.buttons.back_to_mypage")}", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
 
   <div class="flex-col items-center justify-center w-full max-w-2xl px-10 text-white/90 mx-auto">
 
@@ -31,7 +31,7 @@
 
     <!-- 編集ボタン -->
     <div class="text-center">
-      <%= link_to "編集", edit_dark_time_path, class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.edit"), edit_dark_time_path, class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
     </div>
 
   </div>

--- a/app/views/light_times/_form.html.erb
+++ b/app/views/light_times/_form.html.erb
@@ -3,19 +3,19 @@
 
   <!-- 光の時間での行動 -->
   <div>
-    <%= f.label :action, "光の時間での行動", class: "block text-lg mb-2" %>
+    <%= f.label :action, class: "block text-lg mb-2" %>
     <%= f.text_field :action, class: "w-full rounded-lg bg-gray-200 border-2 border-gray-700 px-4 py-2 focus:outline-none focus:ring-4 focus:ring-blue-400" %>
   </div>
 
   <!-- なりたい自分 -->
   <div>
-    <%= f.label :desired_self, "なりたい自分（任意）", class: "block text-lg mb-2" %>
+    <%= optional_label f, :desired_self, class: "block text-lg mb-2" %>
     <%= f.text_area :desired_self, rows: 3, class: "w-full rounded-lg bg-gray-200 border-2 border-gray-700 px-4 py-2 focus:outline-none focus:ring-4 focus:ring-blue-400" %>
   </div>
 
   <!-- 光の時間の特徴 -->
   <div>
-    <%= f.label :characteristic, "光の時間の特徴（任意）", class: "block text-lg mb-2" %>
+    <%= optional_label f, :characteristic, class: "block text-lg mb-2" %>
 
     <p class="text-sm leading-relaxed mb-3">
       本来望んでいる行動に取り組んでいる前後や最中で
@@ -35,7 +35,7 @@
   <!-- ボタン -->
   <div class="flex justify-center gap-6 pt-6">
     <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+    <%= link_to t("shared.buttons.cancel"), cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/light_times/edit.html.erb
+++ b/app/views/light_times/edit.html.erb
@@ -7,7 +7,7 @@
       光の時間での活動内容編集
     </h2>
 
-    <%= render "form", light_time: @light_time, button_text: "更新する", button_class: "bg-green-700 hover:bg-green-800", cancel_path: light_time_path(@light_time) %>
+    <%= render "form", light_time: @light_time, button_text: t("shared.buttons.update"), button_class: "bg-green-700 hover:bg-green-800", cancel_path: light_time_path(@light_time) %>
 
   </div>
 </div>

--- a/app/views/light_times/new.html.erb
+++ b/app/views/light_times/new.html.erb
@@ -7,7 +7,7 @@
       光の時間での活動内容登録
     </h2>
 
-    <%= render "form", light_time: @light_time, button_text: "登録する", button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: mypage_path %>
+    <%= render "form", light_time: @light_time, button_text: t("shared.buttons.create"), button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: mypage_path %>
 
   </div>
 </div>

--- a/app/views/light_times/show.html.erb
+++ b/app/views/light_times/show.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen pb-16 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <!-- 戻るボタン -->
-  <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+  <%= link_to "← #{t("shared.buttons.back_to_mypage")}", mypage_path, class: "mt-6 ml-6 mb-20 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
 
   <div class="flex-col items-center justify-center w-full max-w-2xl px-10 mx-auto">
     <h1 class="text-2xl font-bold text-center mb-10">
@@ -30,8 +30,8 @@
 
     <!-- 編集ボタン -->
     <div class="flex justify-center gap-10 text-center">
-      <%= link_to "編集", edit_light_time_path(@light_time), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
-      <%= link_to "削除", light_time_path(@light_time), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.edit"), edit_light_time_path(@light_time), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.destroy"), light_time_path(@light_time), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
     </div>
 
   </div>

--- a/app/views/mypages/_dark_time.html.erb
+++ b/app/views/mypages/_dark_time.html.erb
@@ -26,7 +26,7 @@
         登録されていません<br>
         新規登録しましょう
       </p>
-      <%= link_to "新規登録", new_dark_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.new"), new_dark_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 text-white/90 font-semibold transition duration-200" %>
     </div>
   </div>
 <% end %>

--- a/app/views/mypages/_light_time.html.erb
+++ b/app/views/mypages/_light_time.html.erb
@@ -47,7 +47,7 @@
         登録されていません<br>
         新規登録しましょう
       </p>
-      <%= link_to "新規登録", new_light_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.new"), new_light_time_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
     </div>
   </div>
 <% end %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -9,7 +9,7 @@
 
       <% if both_times_present?(@dark_time, @light_time) %>
         <div class="hidden md:flex flex-col gap-2 items-stretch justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
-          <%= link_to "新規登録", new_light_time_path, class: "w-full text-xs text-center text-zinc-800 inline-block py-1 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+          <%= link_to t("shared.buttons.new"), new_light_time_path, class: "w-full text-xs text-center text-zinc-800 inline-block py-1 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
 
           <%= link_to "後悔したと思ったら", new_regret_record_path, class: "w-full text-xs leading-tight text-center text-white/90 inline-block py-1.5 rounded-2xl bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200" %>
         </div>
@@ -76,7 +76,7 @@
         <!-- スマホ対応画面における新規登録ボタン -->
         <% if both_times_present?(@dark_time, @light_time) %>
           <div class="md:hidden flex flex-col items-center gap-3">
-            <%= link_to "新規登録", new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
+            <%= link_to t("shared.buttons.new"), new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
 
             <%= link_to "後悔したと思ったら", new_regret_record_path, class: "text-center text-white/90 inline-block px-6 py-2 rounded-full bg-linear-to-r from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% hover:from-violet-700 hover:via-indigo-500 hover:to-indigo-200 font-semibold transition duration-200" %>
           </div>

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -110,6 +110,6 @@
       </div>
     </div>
 
-    <%= link_to "マイページに戻る", mypage_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 text-zinc-800 font-semibold shadow transition duration-200" %>
+    <%= link_to t("shared.buttons.back_to_mypage"), mypage_path, class: "inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 text-zinc-800 font-semibold shadow transition duration-200" %>
   </div>
 </div>

--- a/app/views/purification_times/show.html.erb
+++ b/app/views/purification_times/show.html.erb
@@ -30,14 +30,14 @@
 
   <% if @purification_time.finished? %>
     <div class="flex justify-center">
-      <%= link_to "マイページに戻る", mypage_path, class: "bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
+      <%= link_to t("shared.buttons.back_to_mypage"), mypage_path, class: "bg-red-500 text-white/90 text-lg px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
     </div>
   <% elsif @purification_time.idle? || @purification_time.paused? %>
     <div class="flex justify-center gap-6">
       <button type="button" data-action="click->purification-timer#start" class="bg-green-700 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-green-800 transition duration-200">
         スタート
       </button>
-      <%= link_to "キャンセル", mypage_path, class: "bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
+      <%= link_to t("shared.buttons.cancel"), mypage_path, class: "bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200" %>
     </div>
   <% elsif @purification_time.running? %>
     <button type="button" data-action="click->purification-timer#stop" class="bg-red-500 text-white/90 text-base md:text-lg px-6 md:px-8 py-2 rounded-full hover:bg-red-600 transition duration-200">

--- a/app/views/regret_records/_favorite_filter.html.erb
+++ b/app/views/regret_records/_favorite_filter.html.erb
@@ -2,10 +2,10 @@
 
 <!-- お気に入り絞り込みタブ -->
 <div class="flex justify-center gap-2 mb-8">
-  <%= link_to "すべて",
+  <%= link_to t("shared.buttons.all"),
               regret_records_path,
               class: "px-5 py-2 rounded-full font-bold transition duration-200 #{favorited_active ? 'bg-gray-200 text-gray-600 hover:bg-gray-300' : 'bg-blue-500 text-white/90'}" %>
-  <%= link_to "★ お気に入り",
+  <%= link_to t("shared.buttons.favorite"),
               regret_records_path(q: { favorited_eq: true }),
               class: "px-5 py-2 rounded-full font-bold transition duration-200 #{favorited_active ? 'bg-blue-500 text-white/90' : 'bg-gray-200 text-gray-600 hover:bg-gray-300'}" %>
 </div>

--- a/app/views/regret_records/_form.html.erb
+++ b/app/views/regret_records/_form.html.erb
@@ -3,13 +3,13 @@
 
   <!-- タイトル -->
   <div>
-    <%= f.label :title, "タイトル（任意）", class: "block text-lg mb-2" %>
+    <%= optional_label f, :title, class: "block text-lg mb-2" %>
     <%= f.text_field :title, class: "w-full rounded-lg bg-gray-200 text-zinc-800 border-2 border-gray-700 px-4 py-2 focus:outline-none focus:ring-4 focus:ring-blue-400" %>
   </div>
 
   <!-- 後悔した内容 -->
   <div>
-    <%= f.label :content, "後悔した内容", class: "block text-lg mb-2" %>
+    <%= f.label :content, class: "block text-lg mb-2" %>
 
     <p class="text-sm leading-relaxed mb-3">
       「後悔した1日を過ごしてしまったなあ」と思ったときに、その気持ちや出来事を書き残す場所です。
@@ -23,7 +23,7 @@
   <!-- ボタン -->
   <div class="flex justify-center gap-6 pt-6">
     <%= f.submit button_text, class: "#{button_class} px-6 py-2 rounded-full text-white/90 transition duration-200 shadow-md" %>
-    <%= link_to "キャンセル", cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+    <%= link_to t("shared.buttons.cancel"), cancel_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
   </div>
 
 <% end %>

--- a/app/views/regret_records/edit.html.erb
+++ b/app/views/regret_records/edit.html.erb
@@ -7,7 +7,7 @@
       後悔した1日の記録を編集
     </h2>
 
-    <%= render "form", regret_record: @regret_record, button_text: "更新する", button_class: "bg-green-700 hover:bg-green-800", cancel_path: regret_record_path(@regret_record) %>
+    <%= render "form", regret_record: @regret_record, button_text: t("shared.buttons.update"), button_class: "bg-green-700 hover:bg-green-800", cancel_path: regret_record_path(@regret_record) %>
 
   </div>
 </div>

--- a/app/views/regret_records/new.html.erb
+++ b/app/views/regret_records/new.html.erb
@@ -7,7 +7,7 @@
       後悔した1日の記録
     </h2>
 
-    <%= render "form", regret_record: @regret_record, button_text: "登録する", button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: regret_records_path %>
+    <%= render "form", regret_record: @regret_record, button_text: t("shared.buttons.create"), button_class: "bg-blue-500 hover:bg-blue-600", cancel_path: regret_records_path %>
 
   </div>
 </div>

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -33,8 +33,8 @@
 
     <!-- 編集・削除ボタン -->
     <div class="flex justify-center gap-10 text-center pt-6">
-      <%= link_to "編集", edit_regret_record_path(@regret_record), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
-      <%= link_to "削除", regret_record_path(@regret_record), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.edit"), edit_regret_record_path(@regret_record), class: "bg-green-700 hover:bg-green-800 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
+      <%= link_to t("shared.buttons.destroy"), regret_record_path(@regret_record), data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full text-white/90 font-semibold transition duration-200" %>
     </div>
 
   </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,7 +2,7 @@
 <nav class="fixed top-0 w-full z-50 px-6 py-4 flex justify-between items-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
   <%= link_to "Get The Time", root_path, class: "inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div>
-    <%= link_to "新規登録", new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
+    <%= link_to t("shared.buttons.new"), new_user_registration_path, class: "inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
     <%= link_to "ログイン", new_user_session_path, class: "ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-2 md:px-4 py-2 rounded-lg transition duration-200 text-sm md:text-base" %>
   </div>
 </nav>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -1,7 +1,7 @@
 <div class="text-zinc-800 w-full min-h-screen bg-amber-500 overflow-hidden">
   <!-- ヘッダー -->
     <!-- 戻るボタン -->
-    <%= link_to "← マイページに戻る", mypage_path, class: "fixed top-6 left-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+    <%= link_to "← #{t("shared.buttons.back_to_mypage")}", mypage_path, class: "fixed top-6 left-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
   <!-- メインコンテンツ -->
   <main class= "flex flex-col items-center">
     <div class="w-80 md:w-full max-w-2xl mt-30">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -28,7 +28,7 @@
       <% end %>
 
       <div class="mt-4 text-md text-center">
-        <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
+        <%= link_to t("shared.buttons.login_link"), new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
       </div>
 
     </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -23,7 +23,7 @@
       <% end %>
 
       <div class="mt-4 text-md text-center">
-        <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
+        <%= link_to t("shared.buttons.login_link"), new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
       </div>
 
     </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -14,7 +14,7 @@
 
         <div>
           <%= f.label :email, "メールアドレス", class: "block text-sm font-medium mb-1" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", required: true, class: "w-full bg-gray-200 rounded-md border border-gray-400 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
         </div>
 
         <div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -45,8 +45,8 @@
 
         <!-- 更新ボタン -->
         <div class="flex justify-center gap-4 pt-2">
-          <%= f.submit "更新する", class: "px-6 py-2 rounded-full bg-green-700 text-white/90 font-semibold hover:bg-green-800 transition duration-200 shadow-md" %>
-          <%= link_to "キャンセル", user_account_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
+          <%= f.submit t("shared.buttons.update"), class: "px-6 py-2 rounded-full bg-green-700 text-white/90 font-semibold hover:bg-green-800 transition duration-200 shadow-md" %>
+          <%= link_to t("shared.buttons.cancel"), user_account_path, class: "px-6 py-2 rounded-full bg-red-500 text-white/90 hover:bg-red-600 transition duration-200 shadow-md" %>
         </div>
       <% end %>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -37,7 +37,7 @@
 
       <div class="mt-4 text-md text-center space-y-2">
         <div>
-          <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
+          <%= link_to t("shared.buttons.login_link"), new_session_path(resource_name), class: "text-blue-600 hover:underline" %>
         </div>
         <div>
           <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "text-blue-600 hover:underline" %>

--- a/app/views/users/registrations/show.html.erb
+++ b/app/views/users/registrations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen pb-16">
 
   <!-- 戻るボタン -->
-  <%= link_to "← マイページに戻る", mypage_path, class: "mt-6 ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
+  <%= link_to "← #{t("shared.buttons.back_to_mypage")}", mypage_path, class: "mt-6 ml-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>
 
   <div class="flex items-center justify-center px-6 mt-10">
     <div class="w-full max-w-md bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% rounded-2xl shadow-2xl p-8 text-zinc-800">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,4 +1,16 @@
 ja:
+  shared:
+    buttons:
+      cancel: キャンセル
+      create: 登録する
+      update: 更新する
+      edit: 編集
+      destroy: 削除
+      new: 新規登録
+      back_to_mypage: マイページに戻る
+      all: すべて
+      favorite: ★ お気に入り
+      login_link: ログインはこちら
   defaults:
     flash_message:
       created: "%{item}を作成しました"

--- a/spec/helpers/activity_records_helper_spec.rb
+++ b/spec/helpers/activity_records_helper_spec.rb
@@ -62,4 +62,22 @@ RSpec.describe ActivityRecordsHelper, type: :helper do
       expect(helper.truncate_card_text("今日もよく頑張ったよヨヨヨ")).to eq "今日もよく頑張ったよ..."
     end
   end
+
+  describe "#rating_field" do
+    let(:form) { ActionView::Helpers::FormBuilder.new(:activity_record, ActivityRecord.new, helper, {}) }
+
+    it "見出しラベルを属性名の i18n 訳から生成すること" do
+      html = helper.rating_field(form, :satisfaction, left_label: "不満", right_label: "満足")
+      # 呼び出し側が文字列を渡さなくても human_attribute_name 由来の訳が見出しに出る
+      expect(html).to include(ActivityRecord.human_attribute_name(:satisfaction))
+    end
+
+    it "渡した左右ラベルを出力に含めること" do
+      html = helper.rating_field(form, :satisfaction, left_label: "不満", right_label: "満足")
+      aggregate_failures do
+        expect(html).to include("不満")
+        expect(html).to include("満足")
+      end
+    end
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -65,4 +65,21 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(helper.format_datetime(nil)).to be_nil
     end
   end
+
+  describe "#optional_label" do
+    let(:form) { ActionView::Helpers::FormBuilder.new(:light_time, LightTime.new, helper, {}) }
+
+    it "属性名の i18n 訳に「（任意）」を付けたラベルを生成すること" do
+      html = helper.optional_label(form, :desired_self)
+      aggregate_failures do
+        expect(html).to include("なりたい自分（任意）")
+        expect(html).to include('for="light_time_desired_self"')
+      end
+    end
+
+    it "渡したオプション(class)をラベルに反映すること" do
+      html = helper.optional_label(form, :desired_self, class: "block text-lg")
+      expect(html).to include('class="block text-lg"')
+    end
+  end
 end

--- a/spec/system/password_resets_spec.rb
+++ b/spec/system/password_resets_spec.rb
@@ -48,12 +48,18 @@ RSpec.describe "PasswordResets", type: :system do
     expect(page).to have_content("パスワード（確認用）とパスワードの入力が一致しません")
   end
 
-  it "申請画面でメールアドレスが空だとエラーになる" do
+  it "申請画面でメールアドレスが空だと送信できない" do
     visit new_user_password_path
 
     fill_in "メールアドレス", with: ""
     click_button "再設定用のメールを送信する"
 
-    expect(page).to have_content("メールアドレスを入力してください")
+    # email_field の required により、ブラウザが送信をブロックして申請画面に留まる。
+    # paranoid モードのためサーバ側は空でもリダイレクトしてしまうので、
+    # 「空 → 入力を促す」UX はクライアント側のバリデーションで担保している。
+    aggregate_failures do
+      expect(page).to have_current_path(new_user_password_path)
+      expect(page).to have_no_content(I18n.t("devise.passwords.send_paranoid_instructions"))
+    end
   end
 end


### PR DESCRIPTION
## 概要

Issue #143 の一環として、ビューに直書きされていた UI 文言のうち **フォームラベル** と **繰り返し使われるボタン/リンク文言** を i18n に集約しました。フラッシュ/エラーメッセージは既に i18n 済みで、本 PR はその対象を UI の固定文言まで広げるものです。

Closes #143

## 変更内容

### フォームラベル
- ハードコードしていたラベル文字列を削除し、`f.label` の自動解決（`activerecord` / `activemodel` の `attributes`）に集約。
- 「（任意）」の接尾辞は `optional_label` ヘルパーで付与。属性名そのものはクリーンに保つため、**バリデーションのエラーメッセージに「（任意）」が混入しない**。

### 繰り返しボタン/リンク
複数ビュー横断のため遅延参照ではなく絶対キー `shared.buttons.*` に集約。

| キー | 値 |
|---|---|
| cancel | キャンセル |
| create | 登録する |
| update | 更新する |
| edit / destroy / new | 編集 / 削除 / 新規登録 |
| back_to_mypage | マイページに戻る |
| all / favorite | すべて / ★ お気に入り |
| login_link | ログインはこちら |

- 装飾の「←」は i18n 値に含めず、ビュー側で `"← #{t(...)}"` と前置して現状の見た目を維持。
- 共有 `_form` は文言を引数で受ける汎用のまま、i18n キーは呼び出し元に配置。

### ヘルパー
- `optional_label` を新設。
- `rating_field` の見出しラベルを呼び出し側の引数ではなく `human_attribute_name` 由来に変更。

## テストの変更

### 追加
- `optional_label` / `rating_field` の振る舞い（i18n 訳からラベル生成）に focused test を追加。マークアップ詳細は assert せず、ブリトル化を回避。

### 修正（既存フレークの恒久対応）
本 PR の CI で、i18n 変更とは無関係に間欠的に落ちていた `spec/system/password_resets_spec.rb` の「申請画面でメールアドレスが空だとエラーになる」を修正しました。

- **原因**: テストはバリデーションエラーではなく、申請フォーム冒頭の説明文「登録済みの**メールアドレスを入力してください**…」に `have_content` していた。さらに `config.paranoid = true` のため、空メールでもサーバはエラーを返さずログインへリダイレクトする。結果、Turbo 遷移が間に合うか否かで説明文にマッチするかが変わり、パス/失敗が分かれていた（＝アサーションが実質無意味で、検証対象の挙動も存在しなかった）。
- **対応**: paranoid モード（情報を漏らさない設計）を保ったまま「空 → 入力を促す」UX を成立させるため、申請フォームのメール欄に `required: true` を付与。テストは**クライアント側で送信がブロックされ、申請画面に留まり paranoid フラッシュが出ない**ことを検証する形に刷新。`required` を外すと落ちる、意味のあるテストになっている。

## スコープ外（別途対応予定）
- 単発の文言（`記録する` / `スタート` / `アカウント作成` 等）と単発の戻りリンクは据え置き。
- ポモドーロの「更新する」ボタンはレコード保存とは別文脈のため共有キーに含めず据え置き。
- 未使用 Devise ビュー（unlocks / confirmations）のデッドコード削除は別 PR。
- `spec/system/authentications_spec.rb` の「ログアウトできる」も負荷依存のフレーク傾向（本 PR では再実行で通過）。再発時は待機延長等で別途対応予定。

## 動作確認
- `bundle exec rspec`: **575 examples, 0 failures**
- CI（lint / scan_ruby / rspec）すべてグリーン。
- i18n キーの解決を `rails runner` で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)