### PR TITLE
test: システムスペックの待機時間を延長してログアウトのフレークを抑制

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,11 @@
 require "capybara/rspec"
 require "selenium-webdriver"
 
+# CI の高負荷時、Turbo Drive の遷移＋描画がデフォルトの待機（2秒）を超えて
+# システムスペックが間欠的に落ちることがあるため、待機時間を延長する。
+# 待機を延ばすだけなのでパスするテストには影響せず、本物の失敗もタイムアウト後に検出される。
+Capybara.default_max_wait_time = 5
+
 # Docker開発環境用(リモートChromeコンテナを使用)
 Capybara.register_driver :remote_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new


### PR DESCRIPTION
## 概要

`spec/system/authentications_spec.rb` の「ログアウトできる」が CI 高負荷時に**間欠的に失敗**していた問題に対応します（直近2つの PR で連続発生し、いずれも再実行で通過）。

## 原因

2回の失敗はいずれも同じ種類のレースでした。

| 失敗箇所 | 状況 |
|---|---|
| ログアウト後の `have_current_path` | クリック後もマイページ＋turbo-progress-bar 残存 |
| ログイン後の `have_content("ログインしました。")` | クリック後もログイン画面＋turbo-progress-bar 残存 |

どちらも **click → Turbo Drive 遷移 → 直後のアサーション**が遷移完了前に評価されるもの。失敗時 DOM の先頭に毎回 `.turbo-progress-bar` の style が写り込んでおり、**デフォルト待機（2秒）が切れた時点でまだ遷移中**＝高負荷時に遷移＋描画が 2 秒を超過していました。

## 対応

`Capybara.default_max_wait_time` を **2秒 → 5秒**へ延長（`spec/support/capybara.rb`）。

- 待機を延ばすだけなので**パスするテストには影響せず**、本物の失敗もタイムアウト後にきちんと検出される（false green を生まない）。
- 正常時の実行速度には影響なし（待機は失敗側でのみ消費される）。

## 確認したこと

- ローカルは元々グリーン（CI の高負荷は再現不可）。待機延長後も「ログアウト」を3回連続実行して安定。
- `bundle exec rspec`: **575 examples, 0 failures**。実行時間も従来どおり（約1分）。

## 補足

UI ログイン手順を `sign_in`/`login_as` ヘルパーに置き換える構造的対応（案2）も検討しましたが、まずは最小・低リスクな待機延長で様子を見る方針です。これで再発する場合に案2へ進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)