### PR TITLE
feat: ブラウザタイトルタグをページごとに動的表示 (#204)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,17 @@
 module ApplicationHelper
+  # ブラウザタイトルのサービス名（接尾辞）
+  SITE_TITLE = "Get The Time"
+
   # 任意入力フィールドのラベル接尾辞
   OPTIONAL_LABEL_SUFFIX = "（任意）"
+
+  # <title> の文言を組み立てる。
+  # 各ビューで content_for(:title, ...) が設定されていれば
+  # 「ページ名 | Get The Time」、無ければサービス名のみを返す。
+  def page_title
+    page = content_for(:title)
+    page.present? ? "#{page} | #{SITE_TITLE}" : SITE_TITLE
+  end
 
   # 「（任意）」付きのフォームラベルを生成する。
   # ラベル名は i18n（activerecord/activemodel の attributes）から引くため、

--- a/app/views/activity_records/edit.html.erb
+++ b/app/views/activity_records/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
   <div class="w-80 md:w-full max-w-2xl py-10">
 

--- a/app/views/activity_records/index.html.erb
+++ b/app/views/activity_records/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <!-- 浄化タイマーの時間付与時に表示されるモーダル -->

--- a/app/views/activity_records/new.html.erb
+++ b/app/views/activity_records/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
   <div class="w-80 md:w-full max-w-2xl py-10">
 

--- a/app/views/activity_records/pomodoro_timer.html.erb
+++ b/app/views/activity_records/pomodoro_timer.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div data-controller="pomodoro"
      data-pomodoro-work-duration-value="<%= @pomodoro_setting.work_duration * 60 %>"
      data-pomodoro-break-duration-value="<%= @pomodoro_setting.break_duration * 60 %>"

--- a/app/views/activity_records/show.html.erb
+++ b/app/views/activity_records/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen pb-16 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100%">
 
 <!-- 戻るボタン -->

--- a/app/views/dark_times/edit.html.erb
+++ b/app/views/dark_times/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/dark_times/new.html.erb
+++ b/app/views/dark_times/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/dark_times/show.html.erb
+++ b/app/views/dark_times/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen pb-16 bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100%">
 
   <!-- 戻るボタン -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= page_title %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="Myapp">

--- a/app/views/light_times/edit.html.erb
+++ b/app/views/light_times/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/light_times/new.html.erb
+++ b/app/views/light_times/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/light_times/show.html.erb
+++ b/app/views/light_times/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen pb-16 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% text-zinc-800">
 
   <!-- 戻るボタン -->

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
 
   <!-- 🔹 ハンバーガーメニュー -->

--- a/app/views/mystatuses/show.html.erb
+++ b/app/views/mystatuses/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <% labels = @daily_series.map { |row| row[:date].strftime("%-m/%-d") } %>
 <% light_time_minutes = @daily_series.map { |row| row[:light_time_minutes] } %>
 <% desired_self_percentages = @daily_series.map { |row| row[:desired_self_percentage] } %>

--- a/app/views/purification_times/show.html.erb
+++ b/app/views/purification_times/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div
   data-controller="purification-timer"
   data-purification-timer-remaining-value="<%= @purification_time.remaining_time %>"

--- a/app/views/regret_records/edit.html.erb
+++ b/app/views/regret_records/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/regret_records/index.html.erb
+++ b/app/views/regret_records/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
 
   <!-- ハンバーガーメニュー -->

--- a/app/views/regret_records/new.html.erb
+++ b/app/views/regret_records/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen flex items-center justify-center bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
 
   <div class="w-full max-w-2xl px-10 py-12">

--- a/app/views/regret_records/show.html.erb
+++ b/app/views/regret_records/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="min-h-screen bg-linear-to-b from-violet-600 from-0% via-indigo-400 via-80% to-indigo-100 to-100% text-white/90">
 
   <!-- 戻るボタン -->

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="text-zinc-800 w-full min-h-screen bg-amber-500 overflow-hidden">
   <!-- ヘッダー -->
     <!-- 戻るボタン -->

--- a/app/views/static_pages/reflection_guide.html.erb
+++ b/app/views/static_pages/reflection_guide.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="text-zinc-800 w-full min-h-screen bg-amber-500 overflow-hidden">
   <!-- 戻るボタン -->
   <%= link_to "← マイステータスに戻る", mystatus_path, class: "fixed top-6 left-6 inline-block bg-blue-500 hover:bg-blue-600 text-white/90 px-4 py-2 rounded-lg transition duration-200" %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
   <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
   <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen pb-16">
 
   <!-- 戻るボタン -->

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
   <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">

--- a/app/views/users/registrations/show.html.erb
+++ b/app/views/users/registrations/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen pb-16">
 
   <!-- 戻るボタン -->

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t(".title")) %>
 <div class="bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center min-h-screen">
   <%= link_to "Get The Time", root_path, class: "mt-4 ml-6 inline-block bg-[url('grab_the_light.png')] bg-contain bg-center bg-black/90 bg-no-repeat text-white/90 px-2 md:px-4 py-2 rounded-lg text-sm md:text-base" %>
   <div class="flex items-center justify-center min-h-screen">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,6 +23,16 @@ ja:
   activity_records:
     flash_message:
       require_timer_access: ポモドーロタイマーからアクセスしてください
+    index:
+      title: 活動記録一覧
+    show:
+      title: 活動記録の詳細
+    new:
+      title: 光の時間の特徴を記録
+    edit:
+      title: 活動記録の編集
+    pomodoro_timer:
+      title: ポモドーロタイマー
   regret_summaries:
     flash_message:
       generated: 後悔の傾向を要約しました
@@ -32,3 +42,56 @@ ja:
       appended: 闇の時間の特徴に追記しました
       summary_not_found: 先に要約を作成してください
       dark_time_not_found: 先に闇の時間を登録してください
+  dark_times:
+    show:
+      title: 闇の時間
+    new:
+      title: 闇の時間の登録
+    edit:
+      title: 闇の時間の編集
+  light_times:
+    show:
+      title: 光の時間
+    new:
+      title: 光の時間の登録
+    edit:
+      title: 光の時間の編集
+  mypages:
+    show:
+      title: マイページ
+  mystatuses:
+    show:
+      title: マイステータス
+  purification_times:
+    show:
+      title: 浄化タイマー
+  regret_records:
+    index:
+      title: 後悔の記録一覧
+    show:
+      title: 後悔の記録の詳細
+    new:
+      title: 後悔の記録の登録
+    edit:
+      title: 後悔の記録の編集
+  static_pages:
+    how_to_use:
+      title: 使い方
+    reflection_guide:
+      title: 振り返り方
+  users:
+    sessions:
+      new:
+        title: ログイン
+    registrations:
+      new:
+        title: アカウント作成
+      edit:
+        title: アカウント編集
+      show:
+        title: アカウント情報
+    passwords:
+      new:
+        title: パスワードの再設定
+      edit:
+        title: 新しいパスワードの設定


### PR DESCRIPTION
## 概要

closes #204

ブラウザの `<title>` を各ページごとに動的表示できるようにしました。これまでは常に固定値 `Myapp` が表示されていました。

## 仕組み

- `ApplicationHelper#page_title` を追加。各ビューで `content_for(:title, ...)` が設定されていれば「**ページ名 | Get The Time**」、未設定なら「**Get The Time**」を返す。
- レイアウトの `<title>` を `page_title` ヘルパー経由に変更。
- 各ページのタイトル文言は `config/locales/views/ja.yml` に i18n キーとして集約し、非パーシャルの全ビュー先頭に `<% content_for(:title, t(".title")) %>` を付与（遅延参照のため全ビュー共通の1行）。
- LP（`static_pages/home`）は意図的に未設定とし、「Get The Time」にフォールバック。

## スコープ外（今回は対応せず）

- OGP の `og:title` は従来どおり別管理のまま据え置き（本 issue はブラウザのタイトルタグが対象のため）。

## 動作確認

- `views/ja.yml` の YAML 構文 OK
- 全26タイトルキーが i18n で解決できることを確認（キー漏れなし）
- 実レンダリングで `<title>ログイン | Get The Time</title>` を確認
- RuboCop（`application_helper.rb`）offense 無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)