### PR TITLE
test: page_title ヘルパーのスペックを追加

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -82,4 +82,15 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(html).to include('class="block text-lg"')
     end
   end
+
+  describe "#page_title" do
+    it "content_for(:title) があれば「ページ名 | Get The Time」を返すこと" do
+      helper.content_for(:title, "マイページ")
+      expect(helper.page_title).to eq "マイページ | Get The Time"
+    end
+
+    it "content_for(:title) が未設定ならサービス名のみを返すこと" do
+      expect(helper.page_title).to eq "Get The Time"
+    end
+  end
 end


### PR DESCRIPTION
## 概要

#205（ブラウザタイトルタグの動的表示, issue #204）で追加した `ApplicationHelper#page_title` に対する単体スペックを追加します。

ヘルパーは `content_for(:title)` の有無で出力を分岐するロジックを持つため、その2ケースを検証します。

関連: #204 / #205

## テスト内容

- `content_for(:title)` があれば「ページ名 | Get The Time」を返す
- 未設定ならサービス名「Get The Time」のみを返す

## 動作確認

- `spec/helpers/application_helper_spec.rb` 17 examples / 0 failures
- RuboCop offense 無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)