### PR TITLE
chore: User と1対1モデルの user_id uniqueness validation を削除

### DIFF
--- a/app/models/dark_time.rb
+++ b/app/models/dark_time.rb
@@ -3,7 +3,6 @@ class DarkTime < ApplicationRecord
   SUMMARY_HEADING = "【AIによる後悔の傾向まとめ】".freeze
 
   validates :behavior, presence: true
-  validates :user_id, uniqueness: true
 
   belongs_to :user
 

--- a/app/models/regret_summary.rb
+++ b/app/models/regret_summary.rb
@@ -1,6 +1,5 @@
 class RegretSummary < ApplicationRecord
   validates :content, presence: true
-  validates :user_id, uniqueness: true
 
   belongs_to :user
 end

--- a/spec/models/dark_time_spec.rb
+++ b/spec/models/dark_time_spec.rb
@@ -22,15 +22,6 @@ RSpec.describe DarkTime, type: :model do
       expect(dark_time.errors[:behavior]).to be_present
     end
 
-    it "userごとに1件のみ" do
-      user = create(:user)
-      create(:dark_time, user: user)
-
-      second = build(:dark_time, user: user)
-      expect(second).to be_invalid
-      expect(second.errors[:user_id]).to be_present
-    end
-
     it "userが紐付いていないと無効" do
       dark_time = build(:dark_time, user: nil)
       expect(dark_time).to be_invalid

--- a/spec/models/regret_summary_spec.rb
+++ b/spec/models/regret_summary_spec.rb
@@ -12,15 +12,6 @@ RSpec.describe RegretSummary, type: :model do
       expect(regret_summary.errors[:content]).to be_present
     end
 
-    it "user ごとに1件のみであること" do
-      user = create(:user)
-      create(:regret_summary, user: user)
-
-      second = build(:regret_summary, user: user)
-      expect(second).to be_invalid
-      expect(second.errors[:user_id]).to be_present
-    end
-
     it "user が紐付いていないと無効であること" do
       regret_summary = build(:regret_summary, user: nil)
       expect(regret_summary).to be_invalid


### PR DESCRIPTION
## 概要

Issue #211 対応。User と 1対1 のモデルにおける `validates :user_id, uniqueness: true` を削除し、1対1 モデルの表記を統一します。

このバリデーションは DB の unique インデックスと役割が重複しており、実質ドキュメント役でしかなかったため削除しました。

## 変更内容

| ファイル | 変更 |
|---|---|
| `app/models/dark_time.rb` | `validates :user_id, uniqueness: true` を削除 |
| `app/models/regret_summary.rb` | 同上 |
| `spec/models/dark_time_spec.rb` | 「userごとに1件のみ」テストを削除 |
| `spec/models/regret_summary_spec.rb` | 「user ごとに1件のみ」テストを削除 |

## 安全性

- 両テーブルとも DB の unique インデックス（`index_dark_times_on_user_id` / `index_regret_summaries_on_user_id`、ともに `unique: true`）が残るため、重複は引き続き DB レベルで保証されます。
- コントローラ側も重複生成をガード済み（`dark_times` は `redirect_if_dark_time_exists`、`regret_summaries` は `current_user.regret_summary || build_regret_summary`）。
- validation を持たない他の 1対1 モデル（`PurificationTime` / `PomodoroSetting`）と表記が揃いました。

## テスト

- 該当 spec 13 examples すべて green
- RuboCop オフェンスなし

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)