### PR TITLE
test: issue #213 の RSpec 修正

### DIFF
--- a/spec/forms/activity_record_form_spec.rb
+++ b/spec/forms/activity_record_form_spec.rb
@@ -39,14 +39,18 @@ RSpec.describe ActivityRecordForm, type: :model do
     describe "idle_duration" do
       it "負の値は無効" do
         form.idle_duration = -1
-        expect(form).to be_invalid
-        expect(form.errors[:idle_duration]).to be_present
+        aggregate_failures do
+          expect(form).to be_invalid
+          expect(form.errors[:idle_duration]).to be_present
+        end
       end
 
       it "total_duration を超えると無効" do
         form.idle_duration = form.total_duration + 1
-        expect(form).to be_invalid
-        expect(form.errors[:idle_duration]).to include("は合計時間以下にしてください")
+        aggregate_failures do
+          expect(form).to be_invalid
+          expect(form.errors[:idle_duration]).to include("は合計時間以下にしてください")
+        end
       end
 
       it "total_duration と同値は有効" do
@@ -60,14 +64,18 @@ RSpec.describe ActivityRecordForm, type: :model do
         context attr.to_s do
           it "0 は無効" do
             form.send(:"#{attr}=", 0)
-            expect(form).to be_invalid
-            expect(form.errors[attr]).to be_present
+            aggregate_failures do
+              expect(form).to be_invalid
+              expect(form.errors[attr]).to be_present
+            end
           end
 
           it "6 は無効" do
             form.send(:"#{attr}=", 6)
-            expect(form).to be_invalid
-            expect(form.errors[attr]).to be_present
+            aggregate_failures do
+              expect(form).to be_invalid
+              expect(form.errors[attr]).to be_present
+            end
           end
 
           it "3 は有効" do

--- a/spec/models/activity_record_spec.rb
+++ b/spec/models/activity_record_spec.rb
@@ -40,14 +40,18 @@ RSpec.describe ActivityRecord, type: :model do
 
       it "負の値は無効" do
         activity_record.idle_duration = -1
-        expect(activity_record).to be_invalid
-        expect(activity_record.errors[:idle_duration]).to be_present
+        aggregate_failures do
+          expect(activity_record).to be_invalid
+          expect(activity_record.errors[:idle_duration]).to be_present
+        end
       end
 
       it "total_duration を超えると無効" do
         activity_record.idle_duration = activity_record.total_duration + 1
-        expect(activity_record).to be_invalid
-        expect(activity_record.errors[:idle_duration]).to include("は合計時間以下にしてください")
+        aggregate_failures do
+          expect(activity_record).to be_invalid
+          expect(activity_record.errors[:idle_duration]).to include("は合計時間以下にしてください")
+        end
       end
 
       it "total_duration と同値は有効" do
@@ -71,8 +75,10 @@ RSpec.describe ActivityRecord, type: :model do
           [ 0, 6 ].each do |v|
             it "#{v} は無効" do
               activity_record.send(:"#{attr}=", v)
-              expect(activity_record).to be_invalid
-              expect(activity_record.errors[attr]).to be_present
+              aggregate_failures do
+                expect(activity_record).to be_invalid
+                expect(activity_record.errors[attr]).to be_present
+              end
             end
           end
         end
@@ -265,11 +271,13 @@ RSpec.describe ActivityRecord, type: :model do
     context "PurificationTime がまだ存在しないとき" do
       context ":long_session (90 分) のとき" do
         it "PurificationTime が新規作成されて 1800 秒セットされること" do
-          expect {
-            create(:activity_record, :long_session, user: user, light_time: light_time)
-          }.to change(PurificationTime, :count).by(1)
+          aggregate_failures do
+            expect {
+              create(:activity_record, :long_session, user: user, light_time: light_time)
+            }.to change(PurificationTime, :count).by(1)
 
-          expect(user.reload.purification_time.remaining_time).to eq 1800
+            expect(user.reload.purification_time.remaining_time).to eq 1800
+          end
         end
       end
 
@@ -436,8 +444,10 @@ RSpec.describe ActivityRecord, type: :model do
 
       it "同日の合計時間が分単位で合算されること" do
         # SUM(60 + 120) = 180 分
-        expect(series.size).to eq 1
-        expect(series.first[:light_time_minutes]).to eq 180
+        aggregate_failures do
+          expect(series.size).to eq 1
+          expect(series.first[:light_time_minutes]).to eq 180
+        end
       end
 
       it "同日の本来の自分が平均化されること" do

--- a/spec/models/dark_time_spec.rb
+++ b/spec/models/dark_time_spec.rb
@@ -18,14 +18,18 @@ RSpec.describe DarkTime, type: :model do
 
     it "behaviorがnilだと無効" do
       dark_time = build(:dark_time, behavior: nil)
-      expect(dark_time).to be_invalid
-      expect(dark_time.errors[:behavior]).to be_present
+      aggregate_failures do
+        expect(dark_time).to be_invalid
+        expect(dark_time.errors[:behavior]).to be_present
+      end
     end
 
     it "userが紐付いていないと無効" do
       dark_time = build(:dark_time, user: nil)
-      expect(dark_time).to be_invalid
-      expect(dark_time.errors[:user]).to be_present
+      aggregate_failures do
+        expect(dark_time).to be_invalid
+        expect(dark_time.errors[:user]).to be_present
+      end
     end
   end
 

--- a/spec/models/light_time_spec.rb
+++ b/spec/models/light_time_spec.rb
@@ -33,14 +33,18 @@ RSpec.describe LightTime, type: :model do
 
     it "action が nil の場合は無効であること" do
       light_time = build(:light_time, action: nil)
-      expect(light_time).to be_invalid
-      expect(light_time.errors[:action]).to be_present
+      aggregate_failures do
+        expect(light_time).to be_invalid
+        expect(light_time.errors[:action]).to be_present
+      end
     end
 
     it "user が紐付いていない場合は無効であること" do
       light_time = build(:light_time, user: nil)
-      expect(light_time).to be_invalid
-      expect(light_time.errors[:user]).to be_present
+      aggregate_failures do
+        expect(light_time).to be_invalid
+        expect(light_time.errors[:user]).to be_present
+      end
     end
   end
 
@@ -66,8 +70,10 @@ RSpec.describe LightTime, type: :model do
 
       it "他の light_time は current ではなくなること" do
         described_class.switch_current!(user, next_light_time)
-        expect(current_light_time.reload.is_current).to be false
-        expect(third_light_time.reload.is_current).to be false
+        aggregate_failures do
+          expect(current_light_time.reload.is_current).to be false
+          expect(third_light_time.reload.is_current).to be false
+        end
       end
 
       it "current は1件だけになること" do
@@ -88,12 +94,14 @@ RSpec.describe LightTime, type: :model do
       it "update! 失敗時は rollback されること" do
         allow(next_light_time).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
 
-        expect { described_class.switch_current!(user, next_light_time)
-        }.to raise_error(ActiveRecord::RecordInvalid)
+        aggregate_failures do
+          expect { described_class.switch_current!(user, next_light_time)
+          }.to raise_error(ActiveRecord::RecordInvalid)
 
-        expect(current_light_time.reload.is_current).to be true
-        expect(next_light_time.reload.is_current).to be false
-        expect(third_light_time.reload.is_current).to be false
+          expect(current_light_time.reload.is_current).to be true
+          expect(next_light_time.reload.is_current).to be false
+          expect(third_light_time.reload.is_current).to be false
+        end
       end
     end
   end

--- a/spec/models/pomodoro_setting_spec.rb
+++ b/spec/models/pomodoro_setting_spec.rb
@@ -35,26 +35,34 @@ RSpec.describe PomodoroSetting, type: :model do
 
       it "9 は無効" do
         pomodoro_setting.work_duration = 9
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:work_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:work_duration]).to be_present
+        end
       end
 
       it "91 は無効" do
         pomodoro_setting.work_duration = 91
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:work_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:work_duration]).to be_present
+        end
       end
 
       it "nil は無効" do
         pomodoro_setting.work_duration = nil
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:work_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:work_duration]).to be_present
+        end
       end
 
       it "整数以外は無効" do
         pomodoro_setting.work_duration = 25.5
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:work_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:work_duration]).to be_present
+        end
       end
     end
 
@@ -72,20 +80,26 @@ RSpec.describe PomodoroSetting, type: :model do
 
       it "0 は無効" do
         pomodoro_setting.break_duration = 0
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:break_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:break_duration]).to be_present
+        end
       end
 
       it "31 は無効" do
         pomodoro_setting.break_duration = 31
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:break_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:break_duration]).to be_present
+        end
       end
 
       it "nil は無効" do
         pomodoro_setting.break_duration = nil
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:break_duration]).to be_present
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:break_duration]).to be_present
+        end
       end
     end
 
@@ -99,15 +113,19 @@ RSpec.describe PomodoroSetting, type: :model do
       it "活動時間と同値の休憩時間は無効" do
         pomodoro_setting.work_duration = 10
         pomodoro_setting.break_duration = 10
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:break_duration]).to include("は活動時間未満で設定してください")
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:break_duration]).to include("は活動時間未満で設定してください")
+        end
       end
 
       it "活動時間より長い休憩時間は無効" do
         pomodoro_setting.work_duration = 10
         pomodoro_setting.break_duration = 20
-        expect(pomodoro_setting).to be_invalid
-        expect(pomodoro_setting.errors[:break_duration]).to include("は活動時間未満で設定してください")
+        aggregate_failures do
+          expect(pomodoro_setting).to be_invalid
+          expect(pomodoro_setting.errors[:break_duration]).to include("は活動時間未満で設定してください")
+        end
       end
     end
   end

--- a/spec/models/regret_record_spec.rb
+++ b/spec/models/regret_record_spec.rb
@@ -25,14 +25,18 @@ RSpec.describe RegretRecord, type: :model do
 
     it "content が nil の場合は無効であること" do
       regret_record = build(:regret_record, content: nil)
-      expect(regret_record).to be_invalid
-      expect(regret_record.errors[:content]).to be_present
+      aggregate_failures do
+        expect(regret_record).to be_invalid
+        expect(regret_record.errors[:content]).to be_present
+      end
     end
 
     it "user が紐付いていない場合は無効であること" do
       regret_record = build(:regret_record, user: nil)
-      expect(regret_record).to be_invalid
-      expect(regret_record.errors[:user]).to be_present
+      aggregate_failures do
+        expect(regret_record).to be_invalid
+        expect(regret_record.errors[:user]).to be_present
+      end
     end
   end
 

--- a/spec/models/regret_summary_spec.rb
+++ b/spec/models/regret_summary_spec.rb
@@ -8,14 +8,18 @@ RSpec.describe RegretSummary, type: :model do
 
     it "content が nil だと無効であること" do
       regret_summary = build(:regret_summary, content: nil)
-      expect(regret_summary).to be_invalid
-      expect(regret_summary.errors[:content]).to be_present
+      aggregate_failures do
+        expect(regret_summary).to be_invalid
+        expect(regret_summary.errors[:content]).to be_present
+      end
     end
 
     it "user が紐付いていないと無効であること" do
       regret_summary = build(:regret_summary, user: nil)
-      expect(regret_summary).to be_invalid
-      expect(regret_summary.errors[:user]).to be_present
+      aggregate_failures do
+        expect(regret_summary).to be_invalid
+        expect(regret_summary.errors[:user]).to be_present
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe User, type: :model do
 
     it "nameがないと無効" do
       user = build(:user, name: nil)
-      expect(user).to be_invalid
-      expect(user.errors[:name]).to be_present
+      aggregate_failures do
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to be_present
+      end
     end
 
     it "nameが30文字以内なら有効" do
@@ -87,8 +89,10 @@ RSpec.describe User, type: :model do
 
     it "nameが31文字以上だと無効" do
       user = build(:user, name: "a" * 31)
-      expect(user).to be_invalid
-      expect(user.errors[:name]).to be_present
+      aggregate_failures do
+        expect(user).to be_invalid
+        expect(user.errors[:name]).to be_present
+      end
     end
   end
 
@@ -99,9 +103,11 @@ RSpec.describe User, type: :model do
         password_confirmation: "pass word"
       )
 
-      expect(user).to be_invalid
-      # カスタムメッセージを書いているから、includeを記述
-      expect(user.errors[:password]).to include("にスペースを含めることはできません")
+      aggregate_failures do
+        expect(user).to be_invalid
+        # カスタムメッセージを書いているから、includeを記述
+        expect(user.errors[:password]).to include("にスペースを含めることはできません")
+      end
     end
 
     it "スペースがなければ有効" do
@@ -119,8 +125,10 @@ RSpec.describe User, type: :model do
         password_confirmation: "pass1"
       )
 
-      expect(user).to be_invalid
-      expect(user.errors[:password]).to be_present
+      aggregate_failures do
+        expect(user).to be_invalid
+        expect(user.errors[:password]).to be_present
+      end
     end
 
     it "6文字以上なら有効" do
@@ -235,11 +243,13 @@ RSpec.describe User, type: :model do
         # Google 側で別のメールアドレスになって戻ってきた（uid は不変）
         auth = build_auth(email: "new@example.com", uid: "uid-123")
 
-        expect {
-          described_class.from_omniauth(auth)
-        }.not_to change(described_class, :count)
+        aggregate_failures do
+          expect {
+            described_class.from_omniauth(auth)
+          }.not_to change(described_class, :count)
 
-        expect(described_class.find_by(uid: "uid-123").id).to eq(linked_user.id)
+          expect(described_class.find_by(uid: "uid-123").id).to eq(linked_user.id)
+        end
       end
     end
   end

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe "ActivityRecords", type: :request do
       end
     end
 
+    context "自分と他ユーザーの活動記録があるとき" do
+      before do
+        create(:activity_record, user: user, light_time: light_time, comment: "自分のコメント")
+        create(:activity_record, user: other_user, light_time: other_light_time, comment: "他人のコメント")
+      end
+
+      it "自分の活動記録のみが表示され、他ユーザーの活動記録は表示されないこと" do
+        get activity_records_path
+
+        aggregate_failures do
+          expect(response.body).to include("自分のコメント")
+          expect(response.body).not_to include("他人のコメント")
+        end
+      end
+    end
+
     context "検索パラメータがあるとき" do
       before do
         create(:activity_record, user: user, light_time: light_time, comment: "マッチするコメント")
@@ -92,10 +108,12 @@ RSpec.describe "ActivityRecords", type: :request do
     context "activity_record_form パラメータがないとき" do
       it "ポモドーロタイマーページへリダイレクトすること" do
         get new_activity_record_path
-        expect(response).to redirect_to(pomodoro_timer_activity_records_path)
-        expect(flash[:alert]).to eq(
-          I18n.t("activity_records.flash_message.require_timer_access")
-        )
+        aggregate_failures do
+          expect(response).to redirect_to(pomodoro_timer_activity_records_path)
+          expect(flash[:alert]).to eq(
+            I18n.t("activity_records.flash_message.require_timer_access")
+          )
+        end
       end
     end
   end

--- a/spec/requests/dark_times_spec.rb
+++ b/spec/requests/dark_times_spec.rb
@@ -18,33 +18,37 @@ RSpec.describe "DarkTimes", type: :request do
 
     context "正常系" do
       it "DarkTimeを作成できる" do
-        expect {
-          post dark_time_path, params: {
-            dark_time: {
-              behavior: "スマホを触りすぎる",
-              characteristic: "集中力がない",
-              unwanted_future: "生産性が下がる"
+        aggregate_failures do
+          expect {
+            post dark_time_path, params: {
+              dark_time: {
+                behavior: "スマホを触りすぎる",
+                characteristic: "集中力がない",
+                unwanted_future: "生産性が下がる"
+              }
             }
-          }
-        }.to change(DarkTime, :count).by(1)
+          }.to change(DarkTime, :count).by(1)
 
-        expect(response).to redirect_to(mypage_path)
-        expect(flash[:notice]).to eq(success_message)
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:notice]).to eq(success_message)
+        end
       end
     end
 
     context "異常系" do
       it "behaviorがないと作成できない" do
-        expect {
-          post dark_time_path, params: {
-            dark_time: {
-              behavior: ""
+        aggregate_failures do
+          expect {
+            post dark_time_path, params: {
+              dark_time: {
+                behavior: ""
+              }
             }
-          }
-        }.not_to change(DarkTime, :count)
+          }.not_to change(DarkTime, :count)
 
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(flash[:alert]).to eq(failure_message)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+        end
       end
     end
 
@@ -52,16 +56,18 @@ RSpec.describe "DarkTimes", type: :request do
       let!(:existing_dark_time) { create(:dark_time, user: user) }
 
       it "2件目は作成できず、編集画面にリダイレクトされる" do
-        expect {
-          post dark_time_path, params: {
-            dark_time: { behavior: "別の行動" }
-          }
-        }.not_to change(DarkTime, :count)
+        aggregate_failures do
+          expect {
+            post dark_time_path, params: {
+              dark_time: { behavior: "別の行動" }
+            }
+          }.not_to change(DarkTime, :count)
 
-        expect(response).to redirect_to(edit_dark_time_path)
-        expect(flash[:alert]).to eq(
-          I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
-        )
+          expect(response).to redirect_to(edit_dark_time_path)
+          expect(flash[:alert]).to eq(
+            I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
+          )
+        end
       end
     end
   end
@@ -82,9 +88,11 @@ RSpec.describe "DarkTimes", type: :request do
         dark_time: { behavior: "改善後" }
       }
 
-      expect(response).to redirect_to(dark_time_path)
-      expect(flash[:notice]).to eq(success_message)
-      expect(dark_time.reload.behavior).to eq("改善後")
+      aggregate_failures do
+        expect(response).to redirect_to(dark_time_path)
+        expect(flash[:notice]).to eq(success_message)
+        expect(dark_time.reload.behavior).to eq("改善後")
+      end
     end
 
     it "バリデーションエラー時は更新されない" do
@@ -92,9 +100,11 @@ RSpec.describe "DarkTimes", type: :request do
         dark_time: { behavior: "" }
       }
 
-      expect(response).to have_http_status(:unprocessable_content)
-      expect(flash[:alert]).to eq(failure_message)
-      expect(dark_time.reload.behavior).not_to eq("")
+      aggregate_failures do
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(flash[:alert]).to eq(failure_message)
+        expect(dark_time.reload.behavior).not_to eq("")
+      end
     end
   end
 
@@ -121,10 +131,12 @@ RSpec.describe "DarkTimes", type: :request do
 
       it "編集画面にリダイレクトされる" do
         get new_dark_time_path
-        expect(response).to redirect_to(edit_dark_time_path)
-        expect(flash[:alert]).to eq(
-          I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
-        )
+        aggregate_failures do
+          expect(response).to redirect_to(edit_dark_time_path)
+          expect(flash[:alert]).to eq(
+            I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
+          )
+        end
       end
     end
   end
@@ -142,10 +154,12 @@ RSpec.describe "DarkTimes", type: :request do
     context "DarkTimeが存在しない場合" do
       it "新規作成画面にリダイレクトされる" do
         get edit_dark_time_path
-        expect(response).to redirect_to(new_dark_time_path)
-        expect(flash[:alert]).to eq(
-          I18n.t("defaults.flash_message.not_found", item: DarkTime.model_name.human)
-        )
+        aggregate_failures do
+          expect(response).to redirect_to(new_dark_time_path)
+          expect(flash[:alert]).to eq(
+            I18n.t("defaults.flash_message.not_found", item: DarkTime.model_name.human)
+          )
+        end
       end
     end
   end

--- a/spec/requests/light_times_spec.rb
+++ b/spec/requests/light_times_spec.rb
@@ -66,12 +66,14 @@ RSpec.describe "LightTimes", type: :request do
       end
 
       it "作成できる" do
-        expect {
-          post light_times_path, params: valid_params
-        }.to change(LightTime, :count).by(1)
+        aggregate_failures do
+          expect {
+            post light_times_path, params: valid_params
+          }.to change(LightTime, :count).by(1)
 
-        expect(response).to redirect_to(mypage_path)
-        expect(flash[:notice]).to eq(success_message)
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:notice]).to eq(success_message)
+        end
       end
 
       it "新しく作成したものが current になる" do
@@ -79,11 +81,13 @@ RSpec.describe "LightTimes", type: :request do
 
         post light_times_path, params: valid_params
 
-        expect(LightTime.last.is_current).to be true
+        aggregate_failures do
+          expect(LightTime.last.is_current).to be true
 
-        expect(
-          user.light_times.where(is_current: true).count
-        ).to eq 1
+          expect(
+            user.light_times.where(is_current: true).count
+          ).to eq 1
+        end
       end
     end
 
@@ -98,12 +102,14 @@ RSpec.describe "LightTimes", type: :request do
       end
 
       it "作成できない" do
-        expect {
-          post light_times_path, params: invalid_params
-        }.not_to change(LightTime, :count)
+        aggregate_failures do
+          expect {
+            post light_times_path, params: invalid_params
+          }.not_to change(LightTime, :count)
 
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(flash[:alert]).to eq(failure_message)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+        end
       end
     end
   end
@@ -125,9 +131,11 @@ RSpec.describe "LightTimes", type: :request do
           light_time: { action: "夜散歩" }
         }
 
-        expect(response).to redirect_to(light_time_path(light_time))
-        expect(flash[:notice]).to eq(success_message)
-        expect(light_time.reload.action).to eq ("夜散歩")
+        aggregate_failures do
+          expect(response).to redirect_to(light_time_path(light_time))
+          expect(flash[:notice]).to eq(success_message)
+          expect(light_time.reload.action).to eq ("夜散歩")
+        end
       end
     end
 
@@ -137,9 +145,11 @@ RSpec.describe "LightTimes", type: :request do
           light_time: { action: "" }
         }
 
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(flash[:alert]).to eq(failure_message)
-        expect(light_time.reload.action).not_to eq("")
+        aggregate_failures do
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(flash[:alert]).to eq(failure_message)
+          expect(light_time.reload.action).not_to eq("")
+        end
       end
 
       it "他人のデータは更新できない" do
@@ -149,8 +159,10 @@ RSpec.describe "LightTimes", type: :request do
           light_time: { action: "不正更新" }
         }
 
-        expect(response).to have_http_status(:not_found)
-        expect(other_light_time.reload.action).not_to eq("不正更新")
+        aggregate_failures do
+          expect(response).to have_http_status(:not_found)
+          expect(other_light_time.reload.action).not_to eq("不正更新")
+        end
       end
     end
   end
@@ -165,13 +177,15 @@ RSpec.describe "LightTimes", type: :request do
     end
 
     it "削除できる" do
-      expect {
-        delete light_time_path(current_light_time)
-      }.to change(LightTime, :count).by(-1)
+      aggregate_failures do
+        expect {
+          delete light_time_path(current_light_time)
+        }.to change(LightTime, :count).by(-1)
 
-      expect(response).to have_http_status(:see_other)
-      expect(response).to redirect_to(mypage_path)
-      expect(flash[:notice]).to eq(success_message)
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(mypage_path)
+        expect(flash[:notice]).to eq(success_message)
+      end
     end
 
     it "current 削除時は次が current になる" do
@@ -182,11 +196,13 @@ RSpec.describe "LightTimes", type: :request do
     it "他人のデータは削除できない" do
       other_light_time = create(:light_time, user: other_user)
 
-      expect {
-        delete light_time_path(other_light_time)
-      }.not_to change(LightTime, :count)
+      aggregate_failures do
+        expect {
+          delete light_time_path(other_light_time)
+        }.not_to change(LightTime, :count)
 
-      expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 
@@ -197,10 +213,12 @@ RSpec.describe "LightTimes", type: :request do
     context "正常系" do
       it "current が切り替わる" do
         patch switch_light_time_path(light_time2), headers: { "ACCEPT" => "text/vnd.turbo-stream.html" }
-        expect(response).to have_http_status(:ok)
-        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
-        expect(light_time1.reload.is_current).to be false
-        expect(light_time2.reload.is_current).to be true
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(light_time1.reload.is_current).to be false
+          expect(light_time2.reload.is_current).to be true
+        end
       end
     end
 

--- a/spec/requests/regret_summaries_spec.rb
+++ b/spec/requests/regret_summaries_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe "RegretSummaries", type: :request do
 
     context "正常系" do
       it "RegretSummary が作成されること" do
-        expect {
-          patch generate_regret_summary_path
-        }.to change { user.reload.regret_summary }.from(nil)
+        aggregate_failures do
+          expect {
+            patch generate_regret_summary_path
+          }.to change { user.reload.regret_summary }.from(nil)
 
-        expect(user.regret_summary.content).to eq(summary_text)
+          expect(user.regret_summary.content).to eq(summary_text)
+        end
       end
 
       it "既存の要約があるときは内容が更新されること" do

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -56,6 +56,26 @@ RSpec.describe "User Registrations", type: :request do
         end
       end
 
+      it "登録失敗する（emailが既に登録済み）" do
+        create(:user, email: "taken@example.com")
+
+        aggregate_failures do
+          expect {
+            post user_registration_path, params: {
+              user: {
+                name: "山田太郎",
+                email: "taken@example.com",
+                password: "password123",
+                password_confirmation: "password123",
+                agreement: "1"
+              }
+            }
+          }.not_to change(User, :count)
+
+          expect(response.body).to include("メールアドレスが登録できません。別のメールアドレスで登録してください")
+        end
+      end
+
       it "nameがないと登録できない" do
         aggregate_failures do
           expect {

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -38,8 +38,10 @@ RSpec.describe "User Sessions", type: :request do
       delete destroy_user_session_path
 
       # 1. リダイレクトの指示が来ているか確認 (303)
-      expect(response).to have_http_status(:see_other)
-      expect(response).to redirect_to(new_user_session_path)
+      aggregate_failures do
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(new_user_session_path)
+      end
 
       # 2. 指示に従って次のページへ移動する
       follow_redirect!

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -66,19 +66,23 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
 
     it "「集中できない、やる気が出ないときは」をクリックするとモチベーション画面が表示されること" do
       click_on "集中できない、やる気が出ないときは", visible: true
-      expect(page).to have_selector('[data-pomodoro-target="motivationScreen"]:not(.hidden)')
-      expect(page).to have_selector('[data-pomodoro-target="workScreen"].hidden')
-      expect(page).to have_content("夜更かししてしまう")
-      expect(page).to have_content("健康を損なう")
+      aggregate_failures do
+        expect(page).to have_selector('[data-pomodoro-target="motivationScreen"]:not(.hidden)')
+        expect(page).to have_selector('[data-pomodoro-target="workScreen"].hidden')
+        expect(page).to have_content("夜更かししてしまう")
+        expect(page).to have_content("健康を損なう")
+      end
     end
 
     it "モチベーション画面で「いいえ、もう少し頑張ります！」をクリックすると作業画面に戻ること" do
       click_on "集中できない、やる気が出ないときは", visible: true
       click_on "いいえ、もう少し頑張ります！"
-      expect(page).to have_selector('[data-pomodoro-target="workScreen"]:not(.hidden)')
-      expect(page).to have_selector('[data-pomodoro-target="motivationScreen"].hidden')
-      expect(page).to have_content("25:00")
-      expect(page).to have_button("スタート")
+      aggregate_failures do
+        expect(page).to have_selector('[data-pomodoro-target="workScreen"]:not(.hidden)')
+        expect(page).to have_selector('[data-pomodoro-target="motivationScreen"].hidden')
+        expect(page).to have_content("25:00")
+        expect(page).to have_button("スタート")
+      end
     end
 
     context "やること入力フォームに入力して「更新する」をクリックしたとき" do
@@ -280,10 +284,12 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
 
         click_on "記録する"
 
-        expect(page).to have_current_path(activity_records_path)
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.created", item: ActivityRecordForm.model_name.human)
-        )
+        aggregate_failures do
+          expect(page).to have_current_path(activity_records_path)
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.created", item: ActivityRecordForm.model_name.human)
+          )
+        end
       end
 
       it "浄化タイマー獲得モーダルが表示され、OKをクリックすると閉じること" do
@@ -381,8 +387,10 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
 
       it "光の時間の活動内容とコメントが一覧に表示されること" do
         visit activity_records_path
-        expect(page).to have_content("朝のランニング")
-        expect(page).to have_content("集中できた日")
+        aggregate_failures do
+          expect(page).to have_content("朝のランニング")
+          expect(page).to have_content("集中できた日")
+        end
       end
 
       it "レコードをクリックすると詳細ページへ遷移すること" do
@@ -433,8 +441,10 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
         visit activity_records_path
         fill_in "コメント or 活動内容で検索", with: "検索ヒット"
         click_on "検索"
-        expect(page).to have_content("検索ヒット")
-        expect(page).not_to have_content("対象外")
+        aggregate_failures do
+          expect(page).to have_content("検索ヒット")
+          expect(page).not_to have_content("対象外")
+        end
       end
 
       it "一致しないワードのとき「検索結果が見つかりませんでした」と表示されること" do
@@ -465,8 +475,10 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
         visit activity_records_path(q: { favorited_eq: true })
 
         # まずお気に入りのみ表示されていることを確認
-        expect(page).to have_content("お気に入り対象")
-        expect(page).not_to have_content("通常レコード")
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).not_to have_content("通常レコード")
+        end
 
         click_on "すべて"
 
@@ -516,8 +528,10 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
       visit activity_records_path
 
       within("##{ActionView::RecordIdentifier.dom_id(record)}") do
-        expect(page).to have_content("今日もよく頑張ったよ...")
-        expect(page).not_to have_content("今日もよく頑張ったよヨヨヨ")
+        aggregate_failures do
+          expect(page).to have_content("今日もよく頑張ったよ...")
+          expect(page).not_to have_content("今日もよく頑張ったよヨヨヨ")
+        end
       end
     end
 
@@ -631,8 +645,10 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
     before { visit edit_activity_record_path(activity_record) }
 
     it "編集フォームが表示されること" do
-      expect(page).to have_content("光の時間の活動記録編集")
-      expect(page).to have_field("activity_record[comment]", with: "元のコメント")
+      aggregate_failures do
+        expect(page).to have_content("光の時間の活動記録編集")
+        expect(page).to have_field("activity_record[comment]", with: "元のコメント")
+      end
     end
 
     context "正常な値に変更して「更新する」をクリックしたとき" do

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -95,8 +95,10 @@ RSpec.describe "Authentications", type: :system do
     click_button "ログイン"
 
     # ログイン後のリダイレクト完了を待ってからログアウト操作
-    expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
-    expect(page).to have_link("ログアウト")
+    aggregate_failures do
+      expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
+      expect(page).to have_link("ログアウト")
+    end
     click_link "ログアウト"
 
     aggregate_failures do

--- a/spec/system/dark_times_spec.rb
+++ b/spec/system/dark_times_spec.rb
@@ -21,17 +21,19 @@ RSpec.describe "DarkTimes", type: :system do
         # 作成ボタンをクリック
         click_button "登録する"
 
-        # マイページにリダイレクトされる
-        expect(page).to have_current_path(mypage_path)
+        aggregate_failures do
+          # マイページにリダイレクトされる
+          expect(page).to have_current_path(mypage_path)
 
-        # フラッシュメッセージが表示される
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.created", item: DarkTime.model_name.human)
-        )
+          # フラッシュメッセージが表示される
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.created", item: DarkTime.model_name.human)
+          )
 
-        # 作成したDarkTimeが表示される
-        expect(page).to have_content("スマホを触りすぎる")
-        expect(page).to have_content("生産性が下がる")
+          # 作成したDarkTimeが表示される
+          expect(page).to have_content("スマホを触りすぎる")
+          expect(page).to have_content("生産性が下がる")
+        end
       end
 
       it "キャンセルするとマイページへ戻る" do
@@ -51,14 +53,16 @@ RSpec.describe "DarkTimes", type: :system do
         fill_in "避けたい未来", with: "生産性が下がる"
         click_button "登録する"
 
-        # エラーメッセージが表示される
-        expect(page).to have_content("闇の時間での行動を入力してください")
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.not_created", item: DarkTime.model_name.human)
-        )
+        aggregate_failures do
+          # エラーメッセージが表示される
+          expect(page).to have_content("闇の時間での行動を入力してください")
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.not_created", item: DarkTime.model_name.human)
+          )
 
-        # 作成画面に留まる
-        expect(page).to have_current_path(new_dark_time_path)
+          # 作成画面に留まる
+          expect(page).to have_current_path(new_dark_time_path)
+        end
       end
     end
   end
@@ -73,11 +77,13 @@ RSpec.describe "DarkTimes", type: :system do
         fill_in "闇の時間での行動", with: "改善後の行動"
         click_button "更新する"
 
-        expect(page).to have_current_path(dark_time_path)
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.updated", item: DarkTime.model_name.human)
-        )
-        expect(page).to have_content("改善後の行動")
+        aggregate_failures do
+          expect(page).to have_current_path(dark_time_path)
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.updated", item: DarkTime.model_name.human)
+          )
+          expect(page).to have_content("改善後の行動")
+        end
       end
 
       it "キャンセルすると詳細画面へ戻る" do
@@ -96,11 +102,13 @@ RSpec.describe "DarkTimes", type: :system do
         fill_in "闇の時間での行動", with: ""
         click_button "更新する"
 
-        expect(page).to have_content("闇の時間での行動を入力してください")
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.not_updated", item: DarkTime.model_name.human)
-        )
-        expect(page).to have_current_path(edit_dark_time_path)
+        aggregate_failures do
+          expect(page).to have_content("闇の時間での行動を入力してください")
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.not_updated", item: DarkTime.model_name.human)
+          )
+          expect(page).to have_current_path(edit_dark_time_path)
+        end
       end
     end
   end
@@ -111,9 +119,11 @@ RSpec.describe "DarkTimes", type: :system do
     it "詳細ページで内容が表示される" do
       visit dark_time_path
 
-      expect(page).to have_content("スマホを触りすぎる")
-      expect(page).to have_content(dark_time.unwanted_future)
-      expect(page).to have_content(dark_time.characteristic)
+      aggregate_failures do
+        expect(page).to have_content("スマホを触りすぎる")
+        expect(page).to have_content(dark_time.unwanted_future)
+        expect(page).to have_content(dark_time.characteristic)
+      end
     end
 
     it "マイページへ戻れる" do
@@ -140,9 +150,11 @@ RSpec.describe "DarkTimes", type: :system do
     it "newページにアクセスすると新規作成画面が表示される" do
       visit new_dark_time_path
 
-      expect(page).to have_content("闇の時間での活動内容登録")
-      expect(page).to have_field("闇の時間での行動")
-      expect(page).to have_button("登録する")
+      aggregate_failures do
+        expect(page).to have_content("闇の時間での活動内容登録")
+        expect(page).to have_field("闇の時間での行動")
+        expect(page).to have_button("登録する")
+      end
     end
   end
 
@@ -152,10 +164,12 @@ RSpec.describe "DarkTimes", type: :system do
     it "newページにアクセスすると編集画面にリダイレクトされる" do
       visit new_dark_time_path
 
-      expect(page).to have_current_path(edit_dark_time_path)
-      expect(page).to have_content(
-        I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
-      )
+      aggregate_failures do
+        expect(page).to have_current_path(edit_dark_time_path)
+        expect(page).to have_content(
+          I18n.t("defaults.flash_message.already_exists", item: DarkTime.model_name.human)
+        )
+      end
     end
   end
 end

--- a/spec/system/light_times_spec.rb
+++ b/spec/system/light_times_spec.rb
@@ -18,14 +18,16 @@ RSpec.describe "LightTimes", type: :system do
 
         click_button "登録する"
 
-        expect(page).to have_current_path(mypage_path)
+        aggregate_failures do
+          expect(page).to have_current_path(mypage_path)
 
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.created", item: LightTime.model_name.human)
-        )
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.created", item: LightTime.model_name.human)
+          )
 
-        expect(page).to have_content("朝のヨガ")
-        expect(page).to have_content("穏やかな自分")
+          expect(page).to have_content("朝のヨガ")
+          expect(page).to have_content("穏やかな自分")
+        end
       end
 
       it "必須項目未入力では作成できないこと" do
@@ -35,12 +37,14 @@ RSpec.describe "LightTimes", type: :system do
 
         click_button "登録する"
 
-        expect(page).to have_content("光の時間での行動を入力してください")
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.not_created", item: LightTime.model_name.human)
-        )
+        aggregate_failures do
+          expect(page).to have_content("光の時間での行動を入力してください")
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.not_created", item: LightTime.model_name.human)
+          )
 
-        expect(page).to have_current_path(new_light_time_path)
+          expect(page).to have_current_path(new_light_time_path)
+        end
       end
 
       it "キャンセルでマイページへ戻ること" do
@@ -58,9 +62,11 @@ RSpec.describe "LightTimes", type: :system do
       it "詳細が表示されること" do
         visit light_time_path(light_time)
 
-        expect(page).to have_content("朝のヨガ")
-        expect(page).to have_content("穏やかな自分")
-        expect(page).to have_content("リラックス効果")
+        aggregate_failures do
+          expect(page).to have_content("朝のヨガ")
+          expect(page).to have_content("穏やかな自分")
+          expect(page).to have_content("リラックス効果")
+        end
       end
 
       it "マイページへ戻れること" do
@@ -92,14 +98,16 @@ RSpec.describe "LightTimes", type: :system do
         fill_in "光の時間での行動", with: "夜の読書"
         click_button "更新する"
 
-        expect(page).to have_current_path(
-          light_time_path(light_time)
-        )
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.updated", item: LightTime.model_name.human)
-        )
+        aggregate_failures do
+          expect(page).to have_current_path(
+            light_time_path(light_time)
+          )
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.updated", item: LightTime.model_name.human)
+          )
 
-        expect(page).to have_content("夜の読書")
+          expect(page).to have_content("夜の読書")
+        end
       end
 
       it "必須項目未入力では更新できないこと" do
@@ -109,13 +117,15 @@ RSpec.describe "LightTimes", type: :system do
 
         click_button "更新する"
 
-        expect(page).to have_content("光の時間での行動を入力してください")
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.not_updated", item: LightTime.model_name.human)
-        )
-        expect(page).to have_current_path(
-          edit_light_time_path(light_time)
-        )
+        aggregate_failures do
+          expect(page).to have_content("光の時間での行動を入力してください")
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.not_updated", item: LightTime.model_name.human)
+          )
+          expect(page).to have_current_path(
+            edit_light_time_path(light_time)
+          )
+        end
       end
 
       it "キャンセルで詳細画面へ戻ること" do
@@ -139,11 +149,13 @@ RSpec.describe "LightTimes", type: :system do
           click_link "削除"
         end
 
-        expect(page).to have_current_path(mypage_path)
+        aggregate_failures do
+          expect(page).to have_current_path(mypage_path)
 
-        expect(page).to have_content(
-          I18n.t("defaults.flash_message.deleted", item: LightTime.model_name.human)
-        )
+          expect(page).to have_content(
+            I18n.t("defaults.flash_message.deleted", item: LightTime.model_name.human)
+          )
+        end
       end
 
       context "current を削除した場合" do
@@ -157,8 +169,10 @@ RSpec.describe "LightTimes", type: :system do
             click_link "削除"
           end
 
-          expect(page).to have_current_path(mypage_path)
-          expect(page).to have_content("夜の読書")
+          aggregate_failures do
+            expect(page).to have_current_path(mypage_path)
+            expect(page).to have_content("夜の読書")
+          end
         end
       end
     end
@@ -176,9 +190,11 @@ RSpec.describe "LightTimes", type: :system do
 
         find("button", text: ">").click
 
-        expect(page).to have_content("夜の読書")
+        aggregate_failures do
+          expect(page).to have_content("夜の読書")
 
-        expect(light_time2.reload.is_current).to be true
+          expect(light_time2.reload.is_current).to be true
+        end
       end
     end
 
@@ -220,9 +236,11 @@ RSpec.describe "LightTimes", type: :system do
       it "新規登録導線が表示されること" do
         visit mypage_path
 
-        expect(page).to have_content("登録されていません")
+        aggregate_failures do
+          expect(page).to have_content("登録されていません")
 
-        expect(page).to have_link("新規登録", href: new_light_time_path)
+          expect(page).to have_link("新規登録", href: new_light_time_path)
+        end
       end
     end
 
@@ -234,8 +252,10 @@ RSpec.describe "LightTimes", type: :system do
       it "切り替えボタンが表示されないこと" do
         visit mypage_path
 
-        expect(page).not_to have_button("<")
-        expect(page).not_to have_button(">")
+        aggregate_failures do
+          expect(page).not_to have_button("<")
+          expect(page).not_to have_button(">")
+        end
       end
     end
 
@@ -248,8 +268,10 @@ RSpec.describe "LightTimes", type: :system do
       it "切り替えボタンが表示されること" do
         visit mypage_path
 
-        expect(page).to have_button("<")
-        expect(page).to have_button(">")
+        aggregate_failures do
+          expect(page).to have_button("<")
+          expect(page).to have_button(">")
+        end
       end
     end
   end

--- a/spec/system/purification_times_spec.rb
+++ b/spec/system/purification_times_spec.rb
@@ -178,8 +178,10 @@ RSpec.describe "PurificationTimes", type: :system do
       click_on "スタート"
 
       # location.reload() 後の「終了する」ボタンが表示されるのを確認
-      expect(page).to have_button("終了する")
-      expect(purification_time.reload).to be_running
+      aggregate_failures do
+        expect(page).to have_button("終了する")
+        expect(purification_time.reload).to be_running
+      end
     end
   end
 
@@ -198,8 +200,10 @@ RSpec.describe "PurificationTimes", type: :system do
         end
 
         # reload 後、remaining_time が 0 になっている
-        expect(page).to have_content("0 分 00 秒")
-        expect(purification_time.reload.remaining_time).to eq 0
+        aggregate_failures do
+          expect(page).to have_content("0 分 00 秒")
+          expect(purification_time.reload.remaining_time).to eq 0
+        end
       end
     end
 

--- a/spec/system/regret_records_spec.rb
+++ b/spec/system/regret_records_spec.rb
@@ -207,8 +207,10 @@ RSpec.describe "RegretRecords", type: :system do
         visit regret_records_path(q: { favorited_eq: true })
 
         # まずお気に入りのみ表示されていることを確認
-        expect(page).to have_content("お気に入り対象")
-        expect(page).not_to have_content("通常レコード")
+        aggregate_failures do
+          expect(page).to have_content("お気に入り対象")
+          expect(page).not_to have_content("通常レコード")
+        end
 
         click_on "すべて"
 

--- a/spec/system/regret_summaries_spec.rb
+++ b/spec/system/regret_summaries_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe "RegretSummaries", type: :system do
         click_on "要約する"
 
         # 要約パネルに生成結果と追記ボタンが表示される
-        expect(page).to have_content(summary_text)
-        expect(page).to have_button("闇の時間の特徴へ追記する")
+        aggregate_failures do
+          expect(page).to have_content(summary_text)
+          expect(page).to have_button("闇の時間の特徴へ追記する")
+        end
 
         click_on "闇の時間の特徴へ追記する"
 


### PR DESCRIPTION
## 概要
Issue #213 のチェックリスト3項目に対応した RSpec の修正です。

Closes #213

## 対応内容

### ① index で他人の活動記録が表示されないテストの追加
`spec/requests/activity_records_spec.rb` の `GET /activity_records` に、自分と他ユーザーのレコードを作成し「自分のコメントは表示・他人のコメントは非表示」を検証する example を追加。`current_user.activity_records` でのスコープ漏れを検出できるようにしました。

### ② email taken のテスト追加
`spec/requests/users/registrations_spec.rb` の異常系に、登録済みメールでの再登録が失敗し、`devise.ja.yml` の `errors...email.taken`（`メールアドレスが登録できません。別のメールアドレスで登録してください`）が表示されることを検証する example を追加。

### ③ aggregate_failures の網羅確認（全作成ファイル）
「単一アクション後に独立した複数 expect が並ぶ」 example を機械抽出し、各箇所を目視判定のうえ `aggregate_failures` で統一しました（model / form / request / system の計19ファイル）。

**囲った例**
- `be_invalid` + `errors[...]` のバリデーションペア
- `expect { }.to change` ブロック + レスポンス検証
- Capybara の連続する `have_content` / `have_button` クラスタ

**意図的に囲わなかった例**
- `follow_redirect!` を挟む逐次アサーション
- 途中に別アクションが入る対話フロー（モーダル → OK クリック → 再検証 など）
- 時間依存の逐次 wait（ポモドーロの「休憩画面待ち → 作業画面待ち」）

## 確認
- `bundle exec rspec` … 592 examples, 0 failures
- `bin/rubocop`（変更21ファイル）… no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)