### PR TITLE
test: ログイン/ログアウト system spec の Turbo 遷移待ちを堅牢化 (#218)

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,7 +4,8 @@ require "selenium-webdriver"
 # CI の高負荷時、Turbo Drive の遷移＋描画がデフォルトの待機（2秒）を超えて
 # システムスペックが間欠的に落ちることがあるため、待機時間を延長する。
 # 待機を延ばすだけなのでパスするテストには影響せず、本物の失敗もタイムアウト後に検出される。
-Capybara.default_max_wait_time = 5
+# 5秒でも main マージ後 CI で間欠失敗(#218)したため 10秒へ引き上げ。
+Capybara.default_max_wait_time = 10
 
 # Docker開発環境用(リモートChromeコンテナを使用)
 Capybara.register_driver :remote_chrome do |app|

--- a/spec/system/authentications_spec.rb
+++ b/spec/system/authentications_spec.rb
@@ -74,8 +74,11 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード", with: "password123"
     click_button "ログイン"
 
+    # 先に Turbo 遷移の完了(URL が root へ変わる)を待ってから内容を検証する。
+    # CI 高負荷時に遷移が遅れてもログイン画面のまま即評価して落ちないようにする。
+    expect(page).to have_current_path(root_path, wait: 10)
+
     aggregate_failures do
-      expect(page).to have_current_path(root_path)
       expect(page).to have_content(
         I18n.t("devise.sessions.signed_in")
       )
@@ -94,7 +97,9 @@ RSpec.describe "Authentications", type: :system do
     fill_in "パスワード", with: "password123"
     click_button "ログイン"
 
-    # ログイン後のリダイレクト完了を待ってからログアウト操作
+    # ログイン後のリダイレクト(Turbo 遷移)完了を待ってからログアウト操作。
+    # 先に URL の変化を同期点として待つことで、CI 高負荷時の遅延に強くする。
+    expect(page).to have_current_path(root_path, wait: 10)
     aggregate_failures do
       expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
       expect(page).to have_link("ログアウト")


### PR DESCRIPTION
## 概要

main マージ後の CI で間欠的に失敗していた system spec を堅牢化する。

Closes #218

## 背景

`spec/system/authentications_spec.rb`「ログアウトできる」が main マージ後 CI で間欠失敗していた。テスト名はログアウトだが、実際の失敗箇所は **ログイン直後の検証**で、`click_button "ログイン"` 後の Turbo 遷移（→ `mypages#show`）が `Capybara.default_max_wait_time`（5秒）を超え、ログイン画面のままアサーションが評価されていた。`config.order = :random` による seed 差 × ランナー負荷で再現していた純粋なタイミング起因のフレーキー（詳細は #218）。

## 変更

- `spec/system/authentications_spec.rb`: 「ログインできる」「ログアウトできる」で `click_button "ログイン"` 直後に `have_current_path(root_path, wait: 10)` を同期点として追加し、Turbo 遷移完了を待ってから内容を検証する。
- `spec/support/capybara.rb`: 保険として `default_max_wait_time` を 5 → 10 秒へ引き上げ。

## 確認

```
docker compose exec web bundle exec rspec spec/system/authentications_spec.rb
7 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
