### PR TITLE
config: 本番で force_ssl / assume_ssl を有効化 #222

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       logger (~> 1.5)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
     csv (3.3.5)
@@ -619,7 +619,7 @@ CHECKSUMS
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,10 +25,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
## 概要

`config/environments/production.rb` の `config.force_ssl` と `config.assume_ssl` のコメントアウトを解除し、本番環境で有効化する。Closes #222

## 変更内容

| 設定 | 役割 |
| --- | --- |
| `config.assume_ssl = true` | Render の SSL 終端プロキシ越しに届く平文 HTTP リクエストを「SSL 接続だった」とみなす（`request.ssl?` が true に）。force_ssl のリダイレクトループを防ぐ。 |
| `config.force_ssl = true` | HTTP→HTTPS リダイレクト / HSTS ヘッダ付与 / secure cookie を有効化。 |

## 効果

これまで HTTPS 強制は Render のエッジ任せ（一枚岳）だったが、本変更で Rails 層でも HTTPS を前提に動く多重防御になる。特に **secure cookie 属性** と **HSTS** が効くのが実質的な改善点。

## ヘルスチェックについて

`assume_ssl = true` により全リクエストが SSL とみなされ force_ssl のリダイレクト自体が発生しないため、`/up` を除外する `config.ssl_options` の有効化は不要（コメントのまま）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)