### PR TITLE
chore: msgpack を 1.8.3 に更新し脆弱性 (CVE-2026-54522) を解消 #224

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     multipart-post (2.4.1)
@@ -680,7 +680,7 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
-  msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   multi_xml (0.9.1) sha256=7ce766b59c17241ed62976caeae1fae9b2431b263398c35396239a68c4a64e57
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996


### PR DESCRIPTION
## 概要
`bundler-audit` が検出した `msgpack 1.8.0` の脆弱性 (CVE-2026-54522 / GHSA-4mrv-5p47-p938) を解消する。`bundle update msgpack --conservative` で 1.8.0 → 1.8.3 に更新。

- 依存元: bootsnap 経由の間接依存 (`msgpack (~> 1.2)`)
- 修正版: `>= 1.8.2`
- 変更は Gemfile.lock の msgpack 行のみ
- ローカルで `bin/bundler-audit check` が `No vulnerabilities found` になることを確認済み

これにより main の `scan_ruby` が緑に戻り、Dependabot 各 PR (#225) の CI ブロックも解消される。

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)