### PR TITLE
fix: LightTime 削除の堅牢性を改善（0件フォールバックとトランザクション化） #209

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -63,10 +63,18 @@ class ActivityRecordsController < ApplicationController
   end
 
   def pomodoro_timer
-    # タスク内容を登録のためこちらでインスタンス化
-    @activity_record = current_user.activity_records.build(task: params.permit(:task)[:task])
     @light_time = current_user.light_times.find_by(is_current: true)
     @dark_time = current_user.dark_time
+
+    # 光の時間・闇の時間が揃っていないと画面描画で nil 参照になるため早期リダイレクト。
+    # マイページのタイマー起動ボタンと同じガード条件を URL 直打ちにも適用する。
+    unless helpers.both_times_present?(@dark_time, @light_time)
+      redirect_to mypage_path, alert: t("activity_records.flash_message.require_both_times")
+      return
+    end
+
+    # タスク内容を登録のためこちらでインスタンス化
+    @activity_record = current_user.activity_records.build(task: params.permit(:task)[:task])
     @pomodoro_setting = current_user.pomodoro_setting
   end
 

--- a/app/controllers/light_times_controller.rb
+++ b/app/controllers/light_times_controller.rb
@@ -40,13 +40,7 @@ class LightTimesController < ApplicationController
   end
 
   def destroy
-    was_current = @light_time.is_current
-    @light_time.destroy!
-
-    if was_current
-      next_light_time = current_user.light_times.order(:created_at).first
-      LightTime.switch_current!(current_user, next_light_time) if next_light_time
-    end
+    LightTime.destroy_with_current_reassignment!(current_user, @light_time)
 
     redirect_to mypage_path, notice: t("defaults.flash_message.deleted", item: LightTime.model_name.human), status: :see_other
   end

--- a/app/models/light_time.rb
+++ b/app/models/light_time.rb
@@ -11,6 +11,21 @@ class LightTime < ApplicationRecord
     end
   end
 
+  # current の光の時間を削除した場合は最古のレコードを current に昇格させ、
+  # 「ちょうど 1 件 current」の不変条件を維持する。削除と昇格を単一トランザクションで
+  # まとめることで、途中失敗による「削除済みだが current 不在」の状態を防ぐ。
+  def self.destroy_with_current_reassignment!(user, light_time)
+    transaction do
+      was_current = light_time.is_current
+      light_time.destroy!
+
+      if was_current
+        next_light_time = user.light_times.order(:created_at).first
+        switch_current!(user, next_light_time) if next_light_time
+      end
+    end
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     [ "action" ]  # 検索可能なカラム
   end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,6 +23,7 @@ ja:
   activity_records:
     flash_message:
       require_timer_access: ポモドーロタイマーからアクセスしてください
+      require_both_times: 光の時間と闇の時間を設定してからタイマーを開始してください
     index:
       title: 活動記録一覧
     show:

--- a/spec/models/light_time_spec.rb
+++ b/spec/models/light_time_spec.rb
@@ -106,6 +106,71 @@ RSpec.describe LightTime, type: :model do
     end
   end
 
+  describe ".destroy_with_current_reassignment!" do
+    let(:user) { create(:user) }
+
+    context "current を削除するとき" do
+      let!(:current_light_time) { create(:light_time, :current, user: user) }
+      let!(:oldest_light_time) { create(:light_time, user: user) }
+      let!(:newest_light_time) { create(:light_time, user: user) }
+
+      it "レコードが削除されること" do
+        expect {
+          described_class.destroy_with_current_reassignment!(user, current_light_time)
+        }.to change(described_class, :count).by(-1)
+      end
+
+      it "最古の残レコードが current に昇格すること" do
+        described_class.destroy_with_current_reassignment!(user, current_light_time)
+        aggregate_failures do
+          expect(oldest_light_time.reload.is_current).to be true
+          expect(newest_light_time.reload.is_current).to be false
+          expect(user.light_times.where(is_current: true).count).to eq 1
+        end
+      end
+    end
+
+    context "非 current を削除するとき" do
+      let!(:current_light_time) { create(:light_time, :current, user: user) }
+      let!(:other_light_time) { create(:light_time, user: user) }
+
+      it "current は変わらないこと" do
+        described_class.destroy_with_current_reassignment!(user, other_light_time)
+        expect(current_light_time.reload.is_current).to be true
+      end
+    end
+
+    context "唯一の current を削除して 0 件になるとき" do
+      let!(:only_light_time) { create(:light_time, :current, user: user) }
+
+      it "エラーにならず 0 件になること" do
+        aggregate_failures do
+          expect {
+            described_class.destroy_with_current_reassignment!(user, only_light_time)
+          }.to change(user.light_times, :count).to(0)
+        end
+      end
+    end
+
+    context "昇格に失敗するとき" do
+      let!(:current_light_time) { create(:light_time, :current, user: user) }
+      let!(:next_light_time) { create(:light_time, user: user) }
+
+      it "削除も rollback され current が保たれること" do
+        allow(described_class).to receive(:switch_current!).and_raise(ActiveRecord::RecordInvalid)
+
+        aggregate_failures do
+          expect {
+            described_class.destroy_with_current_reassignment!(user, current_light_time)
+          }.to raise_error(ActiveRecord::RecordInvalid)
+
+          expect(described_class.exists?(current_light_time.id)).to be true
+          expect(current_light_time.reload.is_current).to be true
+        end
+      end
+    end
+  end
+
   describe ".ransackable_attributes" do
     it "action カラムのみ検索可能" do
       expect(described_class.ransackable_attributes).to eq [ "action" ]

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -80,6 +80,35 @@ RSpec.describe "ActivityRecords", type: :request do
         end
       end
     end
+
+    context "光の時間が 0 件のとき" do
+      before { user.light_times.destroy_all }
+
+      it "マイページへリダイレクトすること" do
+        get pomodoro_timer_activity_records_path
+
+        aggregate_failures do
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:alert]).to eq(I18n.t("activity_records.flash_message.require_both_times"))
+        end
+      end
+    end
+
+    context "闇の時間が未設定のとき" do
+      before do
+        user.dark_time.destroy
+        user.reload # has_one の関連キャッシュ（破棄済みインスタンス）をクリア
+      end
+
+      it "マイページへリダイレクトすること" do
+        get pomodoro_timer_activity_records_path
+
+        aggregate_failures do
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:alert]).to eq(I18n.t("activity_records.flash_message.require_both_times"))
+        end
+      end
+    end
   end
 
   # =========================================================


### PR DESCRIPTION
## 概要

`LightTime` 削除まわりの堅牢性を改善する。issue #209 の 2 点に対応。通常フローでは顕在化しないが、エッジケース（全件削除後の URL 直打ち、`switch_current!` 失敗）で不具合になり得る箇所を塞ぐ。

Closes #209

## 変更点

### Fix 1: `pomodoro_timer` の nil フォールバック
- 光の時間を全件削除して 0 件、または闇の時間が未設定のユーザーが `/activity_records/pomodoro_timer` に**直接アクセス**すると、ビューの `@light_time` / `@dark_time` 参照で描画が壊れる可能性があった。
- アクション冒頭で `both_times_present?` を用いた早期リダイレクト（`mypage_path`）を追加。マイページのタイマー起動ボタンと同じガード条件を URL 直打ちにも適用する。
- コントローラからは `helpers.both_times_present?`（ビューコンテキストのプロキシ）で既存ヘルパーを流用。
- flash 用に i18n キー `require_both_times` を追加。

### Fix 2: `destroy` のトランザクション化
- `@light_time.destroy!` と `LightTime.switch_current!` が別トランザクションで、`switch_current!` 失敗時に「削除済みだが current 不在」が残り得た。
- `LightTime.destroy_with_current_reassignment!(user, light_time)` を新設し、削除と current 昇格を単一トランザクションに集約。途中失敗時は削除ごとロールバックする。`switch_current!` と対になる形でドメインロジックをモデルへ集約。

## テスト

- モデルスペック: current 削除時の昇格 / 非 current 削除 / 0 件化 / 昇格失敗時のロールバック
- リクエストスペック: 光 0 件・闇未設定それぞれで `mypage_path` へリダイレクトすることを検証

`spec/models/light_time_spec.rb` / `spec/requests/light_times_spec.rb` / `spec/requests/activity_records_spec.rb` → **69 examples, 0 failures**、RuboCop offense なし。

## 補足

- 本番では `current_user` がリクエスト毎に DB から再ロードされるため、削除済み関連は nil になり正しく動作する。リクエストスペックでは `current_user` が同一オブジェクトで `has_one` の関連キャッシュ（破棄済みインスタンス）が残るため、テスト側で `user.reload` を入れて本番同等の状態を再現している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)