### PR TITLE
docs: README のアプリURLを独自ドメインに変更 #235

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -530,7 +530,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -793,7 +793,7 @@ CHECKSUMS
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](app/assets/images/ogp.png)
 
 ## アプリURL
-https://get-the-time.onrender.com/
+https://get-the-time.com/
 
 ## サービス概要
 **Get The Time** は学校や仕事、家事などで拘束されていない自由時間を


### PR DESCRIPTION
## 概要

README の「アプリURL」セクションが Render のデフォルトドメインを指したままだったため、独自ドメイン `https://get-the-time.com/` に更新しました。

あわせて、CI の `scan_ruby` を通すために `websocket-driver` の脆弱性対応を含めています（詳細は下記）。

Closes #235

## 変更内容

### 1. README のアプリURL変更（本題）

- `README.md:6` のURLを `https://get-the-time.onrender.com/` → `https://get-the-time.com/` へ変更

### 2. websocket-driver 0.8.0 → 0.8.2（CI 修正）

bundler-audit が `websocket-driver 0.8.0` に対する以下4件の脆弱性を検出し、`scan_ruby` が失敗していたため更新しました。

| ID | 内容 | 修正版 |
|---|---|---|
| CVE-2026-54463 | Memory exhaustion via abuse of protocol length headers | >= 0.8.1 |
| CVE-2026-54464 | Resource limit bypass via message compression | >= 0.8.1 |
| CVE-2026-54465 | Memory exhaustion in HTTP header parser | >= 0.8.1 |
| GHSA-2x63-gw47-w4mm | Denial of service via malformed Host header | >= 0.8.2 |

これは本 PR の変更が原因ではありません。main の最後の CI 成功は 7/8 07:13、advisory DB の該当更新は 7/8 16:23 で、脆弱性情報が公開されたのが main の最終 CI 実行**後**だったためです。

`websocket-driver` は `actioncable (8.1.3)` が `>= 0.6.1` として要求する間接依存のため、`bundle update websocket-driver` のみで解決しています。`Gemfile.lock` の差分は当該2行だけで、他の gem のバージョンは変更していません。

## 変更していないもの

`config/environments/production.rb` の `config.hosts` に含まれる `get-the-time.onrender.com` は「Render のデフォルトドメイン（フォールバック用）」として意図的に許可リストへ入っているため据え置きました。

## 確認したこと

- `https://get-the-time.com/` がリダイレクトなしで 200 を返すこと
- ローカルの `bin/bundler-audit check --update` が `No vulnerabilities found` を返すこと
- CI 3ジョブ（`scan_ruby` / `lint` / `rspec`）が全て pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)