### PR TITLE
refactor: both_times_present? を User#light_and_dark_times_present? へ移設 #234

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -68,7 +68,7 @@ class ActivityRecordsController < ApplicationController
 
     # 光の時間・闇の時間が揃っていないと画面描画で nil 参照になるため早期リダイレクト。
     # マイページのタイマー起動ボタンと同じガード条件を URL 直打ちにも適用する。
-    unless helpers.both_times_present?(@dark_time, @light_time)
+    unless current_user.light_and_dark_times_present?
       redirect_to mypage_path, alert: t("activity_records.flash_message.require_both_times")
       return
     end

--- a/app/helpers/mypages_helper.rb
+++ b/app/helpers/mypages_helper.rb
@@ -1,5 +1,0 @@
-module MypagesHelper
-  def both_times_present?(dark_time, light_time)
-    dark_time.present? && light_time.present?
-  end
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,16 @@ class User < ApplicationRecord
 
   after_create :create_pomodoro_setting
 
+  # 光の時間（current）と闇の時間が両方登録済みか。
+  # ポモドーロタイマーの起動可否も、ハンバーガーメニューの記録系リンクの出し分けも、
+  # すべてこの状態から導かれる帰結なので、判定はここに一本化する。
+  # 「光の時間の存在」は is_current: true で定義する。LightTime は作成時に必ず
+  # switch_current! を通り、削除時は destroy_with_current_reassignment! で current を
+  # 昇格させるため、「1 件以上ある」と「current が 1 件ある」は常に一致する。
+  def light_and_dark_times_present?
+    dark_time.present? && light_times.exists?(is_current: true)
+  end
+
   # OmniAuth（Google）認証情報からユーザーを取得・作成する。
   # 検索は次の二段構えで行う:
   #   1. provider/uid（不変かつ一意な外部アカウントの正体）で既存ユーザーを探す。

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, t(".title")) %>
+<% light_and_dark_times_present = current_user.light_and_dark_times_present? %>
 <div class="pb-20 md:pb-0 min-h-screen bg-[url('bg_light_and_darkness_narrow.png')] md:bg-[url('bg_light_and_darkness_wide.png')] bg-cover bg-center overflow-hidden">
 
   <!-- 🔹 ハンバーガーメニュー -->
@@ -8,7 +9,7 @@
   <div class="flex justify-end px-6 pt-6">
     <div class="flex gap-3 md:gap-6">
 
-      <% if both_times_present?(@dark_time, @light_time) %>
+      <% if light_and_dark_times_present %>
         <div class="hidden md:flex flex-col gap-2 items-stretch justify-center bg-stone-300/67 rounded-2xl px-4 py-3 shadow-xl w-40">
           <%= link_to t("shared.buttons.new"), new_light_time_path, class: "w-full text-xs text-center text-zinc-800 inline-block py-1.5 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
 
@@ -60,12 +61,12 @@
 
   <!-- 🔹 メインエリア -->
   <div class="flex items-start md:items-center justify-center min-h-screen px-10">
-    <div class="flex flex-col-reverse my-10 md:my-0 md:flex-row items-center justify-center <%= both_times_present?(@dark_time, @light_time) ? 'gap-20' : 'gap-40 md:gap-80' %>">
+    <div class="flex flex-col-reverse my-10 md:my-0 md:flex-row items-center justify-center <%= light_and_dark_times_present ? 'gap-20' : 'gap-40 md:gap-80' %>">
 
       <!-- 🌑 闇側カード -->
       <%= render "dark_time", dark_time: @dark_time %>
 
-      <% if both_times_present?(@dark_time, @light_time) %>
+      <% if light_and_dark_times_present %>
         <!-- 今日の合計時間&スタートボタン -->
         <%= render "pomodoro_start" %>
       <% end %>
@@ -75,7 +76,7 @@
         <%= render "light_time", light_time: @light_time %>
 
         <!-- スマホ対応画面における新規登録ボタン -->
-        <% if both_times_present?(@dark_time, @light_time) %>
+        <% if light_and_dark_times_present %>
           <div class="md:hidden flex flex-col items-center gap-3">
             <%= link_to t("shared.buttons.new"), new_light_time_path, class: "text-center text-zinc-800 inline-block px-6 py-2 rounded-full bg-linear-to-r from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% hover:from-yellow-500 hover:via-yellow-300 hover:to-yellow-200 font-semibold transition duration-200" %>
 

--- a/app/views/shared/_hamburger_menu.html.erb
+++ b/app/views/shared/_hamburger_menu.html.erb
@@ -17,7 +17,7 @@
 
     <!-- ハンバーガーメニュー展開時 -->
     <nav data-hamburger-target="menu" class="fixed top-0 left-0 h-full w-1/2 md:w-1/3 bg-linear-to-b from-yellow-400 from-0% via-yellow-200 via-80% to-yellow-100 to-100% z-50 transform -translate-x-full transition-transform duration-300">
-      <% setup_complete = both_times_present?(current_user.dark_time, current_user.light_times.first) %>
+      <% setup_complete = current_user.light_and_dark_times_present? %>
       <ul class="pt-35 last:border-b last:border-amber-500">
         <li><%= link_to "マイページ", mypage_path, data: { action: "click->hamburger#close" }, class: nav_link_class(mypage_path) %></li>
         <li><%= link_to "アカウント情報", user_account_path, data: { action: "click->hamburger#close" }, class: nav_link_class(user_account_path) %></li>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,6 +68,63 @@ RSpec.describe User, type: :model do
     end
   end
 
+  # =========================================================
+  # #light_and_dark_times_present?
+  # =========================================================
+  describe "#light_and_dark_times_present?" do
+    let(:user) { create(:user) }
+
+    context "闇の時間と current の光の時間が両方あるとき" do
+      before do
+        create(:dark_time, user: user)
+        create(:light_time, :current, user: user)
+      end
+
+      it "true を返すこと" do
+        expect(user.light_and_dark_times_present?).to be true
+      end
+    end
+
+    context "闇の時間がないとき" do
+      before { create(:light_time, :current, user: user) }
+
+      it "false を返すこと" do
+        expect(user.light_and_dark_times_present?).to be false
+      end
+    end
+
+    context "光の時間が 1 件もないとき" do
+      before { create(:dark_time, user: user) }
+
+      it "false を返すこと" do
+        expect(user.light_and_dark_times_present?).to be false
+      end
+    end
+
+    context "光の時間はあるが current が 1 件もないとき" do
+      before do
+        create(:dark_time, user: user)
+        create(:light_time, user: user, is_current: false)
+      end
+
+      it "false を返すこと（光の時間の存在は is_current: true で定義する）" do
+        expect(user.light_and_dark_times_present?).to be false
+      end
+    end
+
+    context "他ユーザーが両方揃えているとき" do
+      before do
+        other_user = create(:user)
+        create(:dark_time, user: other_user)
+        create(:light_time, :current, user: other_user)
+      end
+
+      it "false を返すこと（他ユーザーのレコードを拾わない）" do
+        expect(user.light_and_dark_times_present?).to be false
+      end
+    end
+  end
+
   describe "nameのバリデーション" do
     it "nameがあれば有効" do
       user = build(:user, name: "テスト")


### PR DESCRIPTION
Closes #234

## 概要

`both_times_present?`（`app/helpers/mypages_helper.rb`）はビュー専用のヘルパーだったが、#209 / PR #233 でコントローラからも `helpers.` プロキシ経由で呼ばれるようになっていた。判定ロジックを `User` へ移設し、意味を一元化する。

## 変更内容

- `User#light_and_dark_times_present?` を追加し、呼び出し 6 箇所すべてを置き換え
- 「光の時間の存在」の定義を `is_current: true` に統一
- `MypagesHelper` は他にメソッドを持たないためファイルごと削除（参照する spec も無し）
- `User` の spec を 5 example 追加

## 述語名について

issue の当初案は `ready_for_timer?` だったが、ハンバーガーメニューが出し分けているのは「活動記録」「マイステータス」「後悔した1日の記録一覧」の 3 リンクで、タイマーとは直接関係がない。タイマー起動可否もリンク解放も「光の時間と闇の時間が両方登録済み」という**同じ状態から導かれる帰結**なので、帰結ではなく状態そのもので命名した。帰結で名付けると、呼び出し元が増えるたびに名前と実態がズレていくため。

`setup_completed?` も検討したが、このアプリには `PomodoroSetting` があり「setup」と「setting」が紛らわしいため見送った。

## is_current への統一について

`LightTime` は作成時に必ず `switch_current!` を通り、削除時は `destroy_with_current_reassignment!` で current を昇格させるため、「1 件以上ある」と「current が 1 件ある」は不変条件として常に一致する。従来の `first` / `is_current: true` / `is_current: true || first` は正常なデータでは同じ結果を返しており、フォールバックは防御的なコードだった。

## 意図的な挙動変更

ハンバーガーメニューは従来 `light_times.first` を見ていたため、「光の時間はあるが current が不在」という壊れたデータでは**メニューのリンクは解放されるのに、タイマー起動はリダイレクトされる**（コントローラは `is_current` を見ていたため）という不整合があった。定義の統一により、この状態では両者が一貫して閉じる。通常のデータでは到達しない経路だが、このケースを含む spec を追加した。

なお `MypagesController` の `find_by(is_current: true) || first` は残している。これは「どのレコードをカードに表示するか」の選択であって存在判定ではないため。

## パフォーマンス

`light_times.exists?` は `has_one` と異なり呼ぶたびにクエリが走る。`mypages/show` は 4 箇所で参照するため、冒頭でローカル変数に束ねて重複発行を避けた（ハンバーガーメニューの既存の `setup_complete` と同じ書き方）。

## 確認

- `bundle exec rspec` → 608 examples, 0 failures
- `bin/rubocop` → 107 files inspected, no offenses detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)