### PR TITLE
refactor: RecordNotFound を rescue_from で捕捉しリダイレクトする #238

### DIFF
--- a/app/controllers/activity_records_controller.rb
+++ b/app/controllers/activity_records_controller.rb
@@ -80,6 +80,10 @@ class ActivityRecordsController < ApplicationController
 
   private
 
+  def not_found_redirect_path
+    activity_records_path
+  end
+
   def set_activity_record
     @activity_record = current_user.activity_records.find(params[:id])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  # 存在しないレコード・他ユーザーのレコードへアクセスした場合、素の 404 ページを見せずに
+  # フラッシュ付きで安全な画面へ戻す
+  rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_not_found
+
   before_action :authenticate_user! # 全体に適用
   before_action :configure_permitted_parameters, if: :devise_controller?
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -16,5 +20,19 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name, :agreement ])
     # 名前をアカウント編集で更新する場合に必要
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+  end
+
+  private
+
+  # DELETE / PATCH からの遷移で Turbo がリクエストメソッドを引き継がないよう 303 を返す
+  def redirect_to_not_found
+    redirect_to not_found_redirect_path,
+                alert: t("defaults.flash_message.record_not_found"),
+                status: :see_other
+  end
+
+  # 戻り先はコントローラごとに上書きする
+  def not_found_redirect_path
+    mypage_path
   end
 end

--- a/app/controllers/light_times_controller.rb
+++ b/app/controllers/light_times_controller.rb
@@ -2,8 +2,6 @@ class LightTimesController < ApplicationController
   before_action :set_light_time, only: %i[show edit update destroy switch]
 
   def switch
-    return head :not_found unless @light_time
-
     LightTime.switch_current!(current_user, @light_time)
 
     respond_to do |format|

--- a/app/controllers/regret_records_controller.rb
+++ b/app/controllers/regret_records_controller.rb
@@ -49,6 +49,10 @@ class RegretRecordsController < ApplicationController
 
   private
 
+  def not_found_redirect_path
+    regret_records_path
+  end
+
   def set_regret_record
     @regret_record = current_user.regret_records.find(params[:id])
   end

--- a/app/javascript/controllers/light_time_switch_controller.js
+++ b/app/javascript/controllers/light_time_switch_controller.js
@@ -63,9 +63,21 @@ export default class extends Controller {
         "X-CSRF-Token": csrfToken || "",
         "Accept": "text/vnd.turbo-stream.html"
       },
-      credentials: "same-origin"
+      credentials: "same-origin",
+      // 自動追従するとリダイレクト先の HTML を Turbo Stream として描画しようとして
+      // 何も起きず、追従先のリクエストでフラッシュも消費されてしまう
+      redirect: "manual"
     })
-    .then(response => response.text())
-    .then(html => Turbo.renderStreamMessage(html))
+    .then(response => {
+      // 削除済みの光の時間へ切り替えようとした場合、サーバはリダイレクトを返す
+      if (response.type === "opaqueredirect") {
+        Turbo.visit(window.location.href)
+        return null
+      }
+      return response.text()
+    })
+    .then(html => {
+      if (html) Turbo.renderStreamMessage(html)
+    })
   }
 }

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
       deleted: "%{item}を削除しました"
       already_exists: "%{item}は既に作成済みです"
       not_found: "%{item}が見つかりません"
+      record_not_found: 対象のデータは見つかりませんでした
   activity_records:
     flash_message:
       require_timer_access: ポモドーロタイマーからアクセスしてください

--- a/spec/requests/activity_records_spec.rb
+++ b/spec/requests/activity_records_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "ActivityRecords", type: :request do
   let(:other_light_time) { create(:light_time, :current, user: other_user) }
   let!(:dark_time)  { create(:dark_time, user: user) }
 
+  let(:not_found_message) { I18n.t("defaults.flash_message.record_not_found") }
+
   before { sign_in user }
 
   # =========================================================
@@ -260,11 +262,15 @@ RSpec.describe "ActivityRecords", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "他ユーザーのレコードにアクセスすると 404 を返すこと" do
+    it "他ユーザーのレコードにアクセスすると一覧へ戻されること" do
       other_activity_record = create(:activity_record, user: other_user, light_time: other_light_time)
 
       get activity_record_path(other_activity_record)
-      expect(response).to have_http_status(:not_found)
+
+      aggregate_failures do
+        expect(response).to redirect_to(activity_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
 
     it "本来の自分が計測済みのとき X 投稿画面へのリンクと文面が描画されること" do
@@ -295,11 +301,15 @@ RSpec.describe "ActivityRecords", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "他ユーザーのレコードにアクセスすると 404 を返すこと" do
+    it "他ユーザーのレコードにアクセスすると一覧へ戻されること" do
       other_activity_record = create(:activity_record, user: other_user, light_time: other_light_time)
 
       get edit_activity_record_path(other_activity_record)
-      expect(response).to have_http_status(:not_found)
+
+      aggregate_failures do
+        expect(response).to redirect_to(activity_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
   end
 
@@ -378,10 +388,11 @@ RSpec.describe "ActivityRecords", type: :request do
 
       let(:other_activity_record) { create(:activity_record, user: other_user, light_time: other_light_time) }
 
-      it "更新できず 404 を返すこと" do
+      it "更新できず一覧へ戻されること" do
         patch activity_record_path(other_activity_record), params: other_bad_params
         aggregate_failures do
-          expect(response).to have_http_status(:not_found)
+          expect(response).to redirect_to(activity_records_path)
+          expect(flash[:alert]).to eq(not_found_message)
           expect(other_activity_record.reload.comment).not_to eq("改ざん")
         end
       end
@@ -433,12 +444,13 @@ RSpec.describe "ActivityRecords", type: :request do
         create(:activity_record, user: other_user, light_time: other_light_time, favorited: false)
       end
 
-      it "更新できず 404 を返すこと" do
+      it "更新できず一覧へ戻されること" do
         aggregate_failures do
           expect {
             patch favorite_activity_record_path(other_activity_record)
           }.not_to change { other_activity_record.reload.favorited }
-          expect(response).to have_http_status(:not_found)
+          expect(response).to redirect_to(activity_records_path)
+          expect(flash[:alert]).to eq(not_found_message)
         end
       end
     end
@@ -470,12 +482,14 @@ RSpec.describe "ActivityRecords", type: :request do
     context "他ユーザーのレコードに削除すると" do
       let!(:other_activity_record) { create(:activity_record, user: other_user, light_time: other_light_time) }
 
-      it "削除できず 404 を返すこと" do
+      it "削除できず一覧へ戻されること" do
         aggregate_failures do
           expect {
             delete activity_record_path(other_activity_record)
           }.not_to change(ActivityRecord, :count)
-          expect(response).to have_http_status(:not_found)
+          expect(response).to have_http_status(:see_other)
+          expect(response).to redirect_to(activity_records_path)
+          expect(flash[:alert]).to eq(not_found_message)
         end
       end
     end

--- a/spec/requests/light_times_spec.rb
+++ b/spec/requests/light_times_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "LightTimes", type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
 
+  let(:not_found_message) { I18n.t("defaults.flash_message.record_not_found") }
+
   before do
     sign_in user
   end
@@ -23,10 +25,14 @@ RSpec.describe "LightTimes", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "他人のデータにはアクセスできない" do
+    it "他人のデータにはアクセスできず、マイページへ戻される" do
       other_light_time = create(:light_time, user: other_user)
       get light_time_path(other_light_time)
-      expect(response).to have_http_status(:not_found)
+
+      aggregate_failures do
+        expect(response).to redirect_to(mypage_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
   end
 
@@ -38,10 +44,14 @@ RSpec.describe "LightTimes", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "他人のデータにはアクセスできない" do
+    it "他人のデータにはアクセスできず、マイページへ戻される" do
       other_light_time = create(:light_time, user: other_user)
       get edit_light_time_path(other_light_time)
-      expect(response).to have_http_status(:not_found)
+
+      aggregate_failures do
+        expect(response).to redirect_to(mypage_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
   end
 
@@ -160,7 +170,8 @@ RSpec.describe "LightTimes", type: :request do
         }
 
         aggregate_failures do
-          expect(response).to have_http_status(:not_found)
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:alert]).to eq(not_found_message)
           expect(other_light_time.reload.action).not_to eq("不正更新")
         end
       end
@@ -201,7 +212,9 @@ RSpec.describe "LightTimes", type: :request do
           delete light_time_path(other_light_time)
         }.not_to change(LightTime, :count)
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(mypage_path)
+        expect(flash[:alert]).to eq(not_found_message)
       end
     end
   end
@@ -223,10 +236,15 @@ RSpec.describe "LightTimes", type: :request do
     end
 
     context "異常系" do
-      it "他人のデータにはアクセスできない" do
+      it "他人のデータにはアクセスできず、マイページへ戻される" do
         other_light_time = create(:light_time, user: other_user)
         patch switch_light_time_path(other_light_time), headers: { "ACCEPT" => "text/vnd.turbo-stream.html" }
-        expect(response).to have_http_status(:not_found)
+
+        aggregate_failures do
+          expect(response).to have_http_status(:see_other)
+          expect(response).to redirect_to(mypage_path)
+          expect(flash[:alert]).to eq(not_found_message)
+        end
       end
     end
   end

--- a/spec/requests/regret_records_spec.rb
+++ b/spec/requests/regret_records_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "RegretRecords", type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
 
+  let(:not_found_message) { I18n.t("defaults.flash_message.record_not_found") }
+
   before do
     sign_in user
   end
@@ -46,12 +48,15 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
 
-    it "他人の記録にアクセスすると 404 を返す" do
+    it "他人の記録にアクセスすると一覧へ戻される" do
       other_regret_record = create(:regret_record, user: other_user)
 
       get regret_record_path(other_regret_record)
 
-      expect(response).to have_http_status(:not_found)
+      aggregate_failures do
+        expect(response).to redirect_to(regret_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
   end
 
@@ -67,12 +72,15 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
 
-    it "他人の記録の編集画面にアクセスすると 404 を返す" do
+    it "他人の記録の編集画面にアクセスすると一覧へ戻される" do
       other_regret_record = create(:regret_record, user: other_user)
 
       get edit_regret_record_path(other_regret_record)
 
-      expect(response).to have_http_status(:not_found)
+      aggregate_failures do
+        expect(response).to redirect_to(regret_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
+      end
     end
   end
 
@@ -108,13 +116,14 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
 
-    it "他人の記録を更新しようとすると 404 を返す" do
+    it "他人の記録を更新しようとすると一覧へ戻される" do
       other_regret_record = create(:regret_record, user: other_user, content: "他人の内容")
 
       patch regret_record_path(other_regret_record), params: { regret_record: { content: "改ざん" } }
 
       aggregate_failures do
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to(regret_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
         expect(other_regret_record.reload.content).to eq("他人の内容")
       end
     end
@@ -192,14 +201,16 @@ RSpec.describe "RegretRecords", type: :request do
       end
     end
 
-    it "他人の記録を削除しようとすると 404 を返し、削除されない" do
+    it "他人の記録を削除しようとすると一覧へ戻され、削除されない" do
       other_regret_record = create(:regret_record, user: other_user)
 
       aggregate_failures do
         expect {
           delete regret_record_path(other_regret_record)
         }.not_to change(RegretRecord, :count)
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:see_other)
+        expect(response).to redirect_to(regret_records_path)
+        expect(flash[:alert]).to eq(not_found_message)
       end
     end
   end
@@ -242,12 +253,13 @@ RSpec.describe "RegretRecords", type: :request do
     context "他ユーザーのレコードに対して操作すると" do
       let!(:other_regret_record) { create(:regret_record, user: other_user, favorited: false) }
 
-      it "更新できず 404 を返すこと" do
+      it "更新できず一覧へ戻されること" do
         aggregate_failures do
           expect {
             patch favorite_regret_record_path(other_regret_record)
           }.not_to change { other_regret_record.reload.favorited }
-          expect(response).to have_http_status(:not_found)
+          expect(response).to redirect_to(regret_records_path)
+          expect(flash[:alert]).to eq(not_found_message)
         end
       end
     end

--- a/spec/system/light_times_spec.rb
+++ b/spec/system/light_times_spec.rb
@@ -198,6 +198,24 @@ RSpec.describe "LightTimes", type: :system do
       end
     end
 
+    context "切り替え先が別タブで削除済みの場合" do
+      it "マイページへ戻され、見つからない旨のメッセージが表示されること" do
+        visit mypage_path
+
+        expect(page).to have_content("朝のヨガ")
+
+        # 別タブでの削除を再現する（画面に描画済みの id だけが残る）
+        light_time2.destroy!
+
+        find("button", text: ">").click
+
+        aggregate_failures do
+          expect(page).to have_content(I18n.t("defaults.flash_message.record_not_found"))
+          expect(page).to have_content("朝のヨガ")
+        end
+      end
+    end
+
     context "キーボード操作（デスクトップ）" do
       before do
         page.driver.browser.manage.window.resize_to(1200, 800)


### PR DESCRIPTION
Closes #238

## 方針

存在しないレコード・他ユーザーのレコードへアクセスした場合に、素の `public/404.html` を見せず、フラッシュ付きで適切な画面へリダイレクトするようにしました。

`ApplicationController` に `rescue_from` を1つ置き、戻り先だけを `not_found_redirect_path` の上書きで差し替えます。

| コントローラ | 戻り先 |
|---|---|
| `ActivityRecordsController` | 活動記録一覧 |
| `RegretRecordsController` | 後悔の記録一覧 |
| `LightTimesController` | マイページ（`index` が無いためデフォルトのまま） |

`RecordNotFound` の発生源は各コントローラの `set_*` にある `current_user.xxx.find(params[:id])` の3箇所だけで、`app/models` / `app/forms` / `app/services` には `find` がないことを確認済みです。

## 303 を返している理由

`destroy` や `favorite` のような DELETE / PATCH からのリダイレクトで、Turbo や `fetch` がリクエストメソッドを引き継いでリダイレクト先に DELETE を投げ直さないようにするためです。GET から返しても無害なので分岐せず常に `:see_other` にしています。

## light_times#switch について

2点対応しました。

**到達不能なガードの削除**: `switch` の先頭にあった `return head :not_found unless @light_time` は、`set_light_time` が `find_by` ではなく `find`（nil を返さず raise する）を使っている以上、評価されても分岐しないデッドコードでした。

**`redirect: "manual"` の追加**: `switch` は `button_to` ではなく生の `fetch` で呼ばれています。`fetch` は既定でリダイレクトを自動追従しますが、`Accept: text/vnd.turbo-stream.html` が追従先にも引き継がれるため `GET /mypage` が `ActionController::UnknownFormat` で **406** になります。返ってくる body は `<turbo-stream>` を含まないので `renderStreamMessage` は何も描画できず、しかも例外経路のためフラッシュが消費されずに残り、後の無関係な画面遷移で唐突に表示されます。

`redirect: "manual"` で追従自体を止め、`opaqueredirect` を検知して `Turbo.visit` で開き直すことで、その場でマイページとフラッシュが表示されるようにしました。実ブラウザ（Selenium）で `follow` / `manual` の `Response` を比較して確認しています。

| | `"follow"` | `"manual"` |
|---|---|---|
| `response.type` | `"basic"` | `"opaqueredirect"` |
| `response.status` | `406` | `0` |
| 読めるヘッダ数 | 4 | 0 |
| `<turbo-stream>` を含む | ✗ | ✗（body 自体が空） |

`favorite` などフレームワークの Turbo が送るリクエストは `Accept` に `text/html` を含むため、リダイレクト先が 200 で描画されます。こちらは影響を受けません。

## テスト

- 既存の request spec 13箇所（`have_http_status(:not_found)`）をリダイレクト＋フラッシュの検証に更新
- 「表示中に別タブで削除された光の時間へ切り替えようとする」ケースの system spec を追加（実ブラウザで検証）
- 全 609 examples green / RuboCop 違反なし

## 補足

作業中に `LightTime.switch_current!` のデータ整合性バグ（対象が既に current のとき `is_current` が 0 件になる）を発見しました。本 PR とはスコープが異なるため別 issue で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)