### PR TITLE
fix: switch_current! で current が 0 件になるバグを修正 #240

### DIFF
--- a/app/models/light_time.rb
+++ b/app/models/light_time.rb
@@ -4,9 +4,12 @@ class LightTime < ApplicationRecord
   belongs_to :user
   has_many :activity_records, dependent: :destroy
 
+  # 切り替え先をリセット対象から除外する。update_all はメモリ上の light_time を
+  # 更新しないため、対象を含めてしまうと「メモリ上は既に true」の場合に
+  # update! が差分なしと判断して UPDATE を発行せず、current が 0 件になる。
   def self.switch_current!(user, light_time)
     transaction do
-      user.light_times.update_all(is_current: false)
+      user.light_times.where.not(id: light_time.id).update_all(is_current: false)
       light_time.update!(is_current: true)
     end
   end

--- a/spec/models/light_time_spec.rb
+++ b/spec/models/light_time_spec.rb
@@ -90,6 +90,26 @@ RSpec.describe LightTime, type: :model do
       end
     end
 
+    context "既に current のレコードを渡すとき" do
+      it "渡した light_time は current のままであること" do
+        described_class.switch_current!(user, current_light_time)
+        expect(current_light_time.reload.is_current).to be true
+      end
+
+      it "current は1件のまま保たれること" do
+        described_class.switch_current!(user, current_light_time)
+        expect(user.light_times.where(is_current: true).count).to eq 1
+      end
+
+      it "他の light_time は current ではないままであること" do
+        described_class.switch_current!(user, current_light_time)
+        aggregate_failures do
+          expect(next_light_time.reload.is_current).to be false
+          expect(third_light_time.reload.is_current).to be false
+        end
+      end
+    end
+
     context "異常系" do
       it "update! 失敗時は rollback されること" do
         allow(next_light_time).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)

--- a/spec/requests/light_times_spec.rb
+++ b/spec/requests/light_times_spec.rb
@@ -233,6 +233,16 @@ RSpec.describe "LightTimes", type: :request do
           expect(light_time2.reload.is_current).to be true
         end
       end
+
+      it "既に current のレコードへ切り替えても current が1件のまま保たれる" do
+        patch switch_light_time_path(light_time1), headers: { "ACCEPT" => "text/vnd.turbo-stream.html" }
+
+        aggregate_failures do
+          expect(response).to have_http_status(:ok)
+          expect(light_time1.reload.is_current).to be true
+          expect(user.light_times.where(is_current: true).count).to eq 1
+        end
+      end
     end
 
     context "異常系" do

--- a/spec/system/light_times_spec.rb
+++ b/spec/system/light_times_spec.rb
@@ -216,6 +216,35 @@ RSpec.describe "LightTimes", type: :system do
       end
     end
 
+    context "別タブで current の光の時間が削除済みの場合" do
+      let!(:dark_time) { create(:dark_time, user: user) }
+
+      it "切り替え後もポモドーロタイマーを開始できること" do
+        visit mypage_path
+
+        expect(page).to have_content("朝のヨガ")
+        expect(page).to have_button("スタート")
+
+        # 別タブでの削除を再現する。DB 上は「夜の読書」が current へ昇格するが、
+        # 画面は「朝のヨガ」を current と信じたまま矢印を描画している。
+        # そのため矢印は「既に current の光の時間」への切り替えを送ることになる。
+        LightTime.destroy_with_current_reassignment!(user, light_time1)
+
+        find("button", text: ">").click
+
+        expect(page).to have_content("夜の読書")
+
+        # 切り替え直後は #light-time-switch しか差し替わらないため、
+        # current が失われても再表示するまで症状が現れない
+        visit mypage_path
+
+        aggregate_failures do
+          expect(page).to have_button("スタート")
+          expect(user.light_times.where(is_current: true).count).to eq 1
+        end
+      end
+    end
+
     context "キーボード操作（デスクトップ）" do
       before do
         page.driver.browser.manage.window.resize_to(1200, 800)


### PR DESCRIPTION
Closes #240

## 概要

`LightTime.switch_current!` に、切り替え先が**既に current** の場合に「ちょうど 1 件 current」の不変条件を壊すバグがありました。全レコードの `is_current` が `false` になり、マイページのポモドーロタイマー起動ボタンが表示されなくなります。

## 原因

```ruby
user.light_times.update_all(is_current: false)   # ① SQL を直接発行
light_time.update!(is_current: true)             # ② 対象だけ true に戻す
```

`update_all` は SQL を直に流すため、メモリ上の `light_time` オブジェクトは書き換わりません。

渡された `light_time` がメモリ上で既に `is_current: true` だと、②はダーティトラッキングにより「差分なし」と判断され **UPDATE 文を1本も発行しません**。①で `false` にされた行がそのまま残り、current が 0 件になります。

`update!` の戻り値は `true`、バリデーションもコールバックも走るため、呼び出し側からは成功したように見えます。これが症状の発見を遅らせていました。

## 修正

リセット対象から切り替え先を除外します。副次的に `switch_current!` が冪等になります。

```ruby
user.light_times.where.not(id: light_time.id).update_all(is_current: false)
light_time.update!(is_current: true)
```

コントローラで早期リターンする案もありましたが、`destroy_with_current_reassignment!` など他の呼び出し元に同じ地雷が残るため、モデル側で直しました。

## 再現シナリオ

2つのタブで同じマイページを開き、光の時間が2件（`lt1` が current）ある状態から:

1. タブ A で `lt1`（current）を削除 → `destroy_with_current_reassignment!` により `lt2` が current へ昇格
2. タブ B は `lt1` を current と信じたまま。「>」をクリックして `lt2` へ切り替えようとする
3. `set_light_time` が読み込む `lt2` は DB 上で既に `is_current: true`
4. ①で全件 false、②が no-op となり current が 0 件

なお `switch.turbo_stream.erb` は `#light-time-switch` しか差し替えないため、**クリック直後は画面に異常が出ません**。次にマイページを表示したときに初めてボタンが消えます。

## テスト

`update!` の no-op が「成功」に見えてしまう性質上、3層で押さえました。

- **model**: 既に current のレコードを渡しても current が 1 件のまま保たれること
- **request**: `switch` アクション経由でも同様であること
- **system**: 矢印操作から実際に stale な id が送られ、再表示後もスタートボタンが残ること

model / request は「既に current の id が渡される」ことを前提として与えているのに対し、system spec はその前提が UI から現実に発生し得ることを通しで確認しています。

いずれも修正を外した状態で失敗すること（current が 0 件・ボタン消失）を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)