### PR TITLE
chore: .claude/ の丸ごと無視をやめ共有設定を残せるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,12 @@
 /vendor/bundle
 /vendor/cache
 
-# Claude Code のローカル状態（メモリ等）
-/.claude/
+# Claude Code: 共有設定はコミットし、個人のローカル状態（メモリ等）は無視する
+# 末尾スラッシュ付きの /.claude/ ではディレクトリごと除外され、中のファイルを ! で
+# 復活させられないため、/.claude/* の形にしている
+/.claude/*
+!/.claude/settings.json
+!/.claude/commands/
+!/.claude/agents/
+!/.claude/skills/
+!/.claude/hooks/


### PR DESCRIPTION
Closes #252

## 変更内容

`.gitignore` の `.claude/` の扱いを、丸ごと無視から「共有設定はコミット・個人のローカル状態は無視」へ変更した。

```gitignore
/.claude/*
!/.claude/settings.json
!/.claude/commands/
!/.claude/agents/
!/.claude/skills/
!/.claude/hooks/
```

`/.claude/`（末尾スラッシュ）はディレクトリごと除外するため git が中を走査せず、`!` による再包含が効かない。そのため `/.claude/*` の形に変えている。この理由はコメントとしてファイル内にも残した。

## 意図

`settings.json`（権限・フック・env などプロジェクト共通設定）やプロジェクト用のスラッシュコマンド・サブエージェント・スキルは `CLAUDE.md` と同じくリポジトリ資産なので共有したい。一方 `settings.local.json`（個人の許可リスト）と `projects/`（セッション状態・メモリ）はマシンローカルなので無視を維持する。

## 動作確認

`git check-ignore` で各パスの判定を確認した。

| パス | 判定 |
|---|---|
| `.claude/settings.json` | 追跡可能 |
| `.claude/commands/deploy.md` | 追跡可能 |
| `.claude/agents/foo.md` | 追跡可能 |
| `.claude/skills/bar/SKILL.md` | 追跡可能 |
| `.claude/hooks/pre.sh` | 追跡可能 |
| `.claude/settings.local.json` | 無視 |
| `.claude/projects/x/memory/MEMORY.md` | 無視 |

現時点で `.claude/` 配下に存在するのは `settings.local.json` と、リポジトリ内に取り残された古い `projects/.../memory/`（実体は `~/.claude/` 側へ移行済み）のみで、いずれも無視対象のまま。よって本 PR で新たにコミットされるファイルはなく、差分は `.gitignore` の 1 ファイルのみ。将来の取りこぼしを防ぐための変更となる。

## CI の経緯

初回の CI では `scan_ruby`（bundler-audit）が失敗したが、本 PR の変更とは無関係だった。同ジョブは毎回 `ruby-advisory-db` を `update` してから `check` するため、コード変更がなくてもアドバイザリ DB の更新だけで失敗する。CI が取得した DB は `last updated: 2026-07-27` で、main の最後の CI 成功（2026-07-14）より後であり、当時 main も同様に失敗する状態にあった。

検出内容は `loofah` / `rails-html-sanitizer` / `mcp` の脆弱性で、#254 として切り出し、#255 で gem を更新して解消した。本 PR はその後 main へリベースしており、リベース後の CI は全ジョブ green。

```
scan_ruby  pass  18s
lint       pass  21s
rspec      pass  2m43s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
