### PR TITLE
json を 2.21.2 に上げて CVE-2026-71847 に対応する #266

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 7.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     kamal (2.12.0)
@@ -653,7 +653,7 @@ CHECKSUMS
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kamal (2.12.0) sha256=c51d1ab085e515470f98d0c0f043637122b5ebf76e8b610cb1fbbed0b7f9b8fa
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e


### PR DESCRIPTION
Closes #266

## 概要

`bundler-audit` が `json` gem に新規の脆弱性を検出し、CI の `scan_ruby` ジョブが失敗するようになったため、`Gemfile.lock` の `json` を `2.21.2` に上げる。

```
Name: json
Version: 2.21.1
CVE: CVE-2026-71847
GHSA: GHSA-9hj4-r449-hfvc
Title: Ruby JSON - JSON::ResumableParser#partial_value dereferences a freed input buffer
       and crashes on truncated duplicate-key streams
Solution: update to '>= 2.21.2'
```

## これは特定の PR が持ち込んだものではない

ruby-advisory-db の更新日が `2026-08-10 08:56` で、**本日公開されたばかりの advisory** である。main の直近 CI（2026-08-09）は成功していたが、いまの main を流せば同じく失敗する。

PR #264 の CI で顕在化したが、同 PR はビューと Stimulus コントローラしか変更しておらず、依存関係には一切触れていない（同 PR の `lint` と `rspec` は通過している）。

## 変更内容

`json` は `Gemfile` に直接指定がない推移的依存なので、`Gemfile.lock` だけを更新した。

```bash
bundle update json --conservative
```

差分は `json` のバージョンとチェックサムの 2 行のみで、他の gem は動いていない。

## 検証

| コマンド | 結果 |
|---|---|
| `bin/bundler-audit check` | **No vulnerabilities found** |
| `bundle exec rspec` | 631 examples, 0 failures |
| `bin/rubocop` | 108 files, no offenses |
| `bin/brakeman --no-pager` | Security Warnings: 0 |

## マージ後

このブランチを main にマージしたあと、#264 に main をマージして CI を緑にする（rerun ではベースが古いままなので反映されない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)