### PR TITLE
start() の再入で setInterval が二重に走るのを防ぐ #265

### DIFF
--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -16,6 +16,8 @@ export default class extends Controller {
     this.pomodoroCount = 0
     this.remainingTime = this.workDurationValue
     this.timerInterval = null
+    // start() の再入ガード。await 中だけ true になる（#265）
+    this.starting = false
     this.endedAt = null
     this.task = this.taskValue
     // 追記して修正できるように、マイページで入力した内容をやることの入力フォームに残しておく。
@@ -85,8 +87,28 @@ export default class extends Controller {
   }
 
   async start() {
-    if (this.timerInterval) return
+    // ✅ 二度押しで setInterval が二重に走るのを防ぐ（#265）。
+    //    this.timerInterval は startTimer() まで、this.firstStartedAt は await の
+    //    後まで設定されないため、この 2 つだけでは isPurificationCounting() の
+    //    往復中に入ってきた 2 回目を弾けない。1 本目は this.timerInterval の
+    //    上書きで参照を失い、二度と clearInterval できなくなる。
+    //    表示ではなくフラグで閉じるのは、CSS が効かない状況でも守るためである。
+    if (this.timerInterval || this.starting) return
+    this.starting = true
 
+    try {
+      // ✅ 押した瞬間に消す。await の後まで画面が何も変わらないと「反応がない」と
+      //    感じて押し直す動機になる。フラグとは別に、動機そのものを断つ。
+      this.startButtonTarget.classList.add("hidden")
+
+      await this.startSession()
+    } finally {
+      this.starting = false
+    }
+  }
+
+  // start() の本体。再入ガードは呼び出し元が持つ。
+  async startSession() {
     // ✅ 最初のスタート時のみ記録
     if (this.firstStartedAt === null) {
       // ✅ 浄化タイマーが別タブで計測中なら、スタート押下の瞬間にサーバへ問い合わせて
@@ -116,7 +138,6 @@ export default class extends Controller {
     }
 
     this.startTimer()
-    this.startButtonTarget.classList.add("hidden")
   }
 
   // 浄化タイマーはサーバに状態を持つので、判定はサーバに問い合わせる

--- a/app/javascript/controllers/pomodoro_controller.js
+++ b/app/javascript/controllers/pomodoro_controller.js
@@ -102,6 +102,11 @@ export default class extends Controller {
       this.startButtonTarget.classList.add("hidden")
 
       await this.startSession()
+    } catch (error) {
+      // ✅ 想定外の失敗で「ボタンも無い・タイマーも動いていない」行き止まりにしない。
+      //    押す前の状態へ戻し、もう一度試せるようにする。
+      this.startButtonTarget.classList.remove("hidden")
+      throw error
     } finally {
       this.starting = false
     }
@@ -114,7 +119,16 @@ export default class extends Controller {
       // ✅ 浄化タイマーが別タブで計測中なら、スタート押下の瞬間にサーバへ問い合わせて
       // 弾く。画面を開いた時点のガードだけでは、両タブを開いた後で浄化タイマーが
       // 後から開始されたケースを検知できない。
-      if (await this.isPurificationCounting()) {
+      const purificationCounting = await this.isPurificationCounting()
+
+      // ✅ 往復の間に離脱していたら、この先の副作用を一切起こさない。
+      //    「キャンセル」は Turbo Drive のリンク遷移なので document は作り直されず、
+      //    disconnect() が済んだ後もこの Promise だけが再開する。そこで
+      //    beforeunload やリースを張ると、片付ける者がいないまま残ってしまう
+      //    （離脱警告が出続け、リースの heartbeat が回り続けて浄化タイマーに入れなくなる）。
+      if (!this.element.isConnected) return
+
+      if (purificationCounting) {
         location.replace("/mypage?locked=purification")
         return
       }

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
       expect(page).to have_current_path(pomodoro_timer_activity_records_path, ignore_query: true)
 
       click_on "スタート", visible: true
-      # 計測が始まって出口が入れ替わるのを待つ
-      expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+      # 出口が入れ替わるのを待つ。startButton の hidden は押した直後に付くので、
+      # fetch の往復が終わったことを表さない
+      expect(page).to have_button("終了する", visible: true, wait: 5)
 
       # Turbo Drive は離脱時の（＝入れ替え済みの）DOM をキャッシュするので、
       # 復元では hidden が入れ替わったまま戻ってくる。connect() が未スタートの
@@ -223,9 +224,9 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
     context "休憩時間が終了したとき" do
       it "作業画面に戻りスタートボタンが表示されること" do
         click_on "スタート", visible: true
-        # start() は fetch を await した後に隠すので、先に「隠れたこと」を待たないと
-        # まだ見えている元のボタンにマッチし、休憩サイクルを回さずに通ってしまう
-        expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+        # スタートが完了した（＝出口が入れ替わった）ことを待つ。ここを飛ばすと
+        # まだ見えている元のスタートボタンにマッチし、休憩サイクルを回さずに通る
+        expect(page).to have_button("終了する", visible: true, wait: 5)
 
         aggregate_failures do
           # 作業3秒 + 休憩2秒 終了後にスタートボタンが再表示される
@@ -237,7 +238,7 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
       it "休憩明けの作業画面では「スタート」「終了する」「集中できない…」が並び、「キャンセル」は戻らないこと" do
         click_on "スタート", visible: true
         # 同上。ここを飛ばすと休憩明けを経ずに assertion が満たされてしまう
-        expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+        expect(page).to have_button("終了する", visible: true, wait: 5)
         expect(page).to have_button("スタート", visible: true, wait: 15)
 
         # 初回スタートで入れ替えた出口は、休憩明けの作業画面でも元に戻さない
@@ -326,8 +327,8 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
         it "スタート後に終了すると確認ダイアログを経て新規作成画面へ遷移すること" do
           relax_timer_durations
           click_on "スタート", visible: true
-          # スタート直後はタイマーが動いているので startButton が hidden になることを確認
-          expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+          # スタートが完了してタイマーが動き出すのを待つ
+          expect(page).to have_button("終了する", visible: true, wait: 5)
 
           accept_confirm("終了してよろしいでしょうか？") do
             within('[data-pomodoro-target="workScreen"]') do
@@ -341,7 +342,7 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
         it "確認ダイアログをキャンセルするとタイマーが継続すること" do
           relax_timer_durations
           click_on "スタート", visible: true
-          expect(page).to have_selector('[data-pomodoro-target="startButton"].hidden', wait: 5)
+          expect(page).to have_button("終了する", visible: true, wait: 5)
 
           dismiss_confirm("終了してよろしいでしょうか？") do
             within('[data-pomodoro-target="workScreen"]') do

--- a/spec/system/activity_records_spec.rb
+++ b/spec/system/activity_records_spec.rb
@@ -161,6 +161,39 @@ RSpec.describe "ActivityRecords システムテスト", type: :system do
           expect(page).to have_content("00:02", wait: 3)
         end
       end
+
+      it "浄化タイマーの問い合わせ中に二度押ししても作業タイマーが二重に走らないこと" do
+        page.execute_script(<<~JS)
+          const el = document.querySelector('[data-controller="pomodoro"]')
+          const controller = window.Stimulus.getControllerForElementAndIdentifier(el, 'pomodoro')
+
+          // 作業を60秒に戻す。3秒のままだとテスト中に満了して、休憩用の
+          // setInterval が 2 本目として数えられてしまう
+          el.dataset.pomodoroWorkDurationValue = 60
+
+          // fetch の往復を 1 秒に引き伸ばして、二度押しが入る窓を作る
+          controller.isPurificationCounting = () => new Promise(r => setTimeout(() => r(false), 1000))
+
+          // 作られた setInterval の間隔を記録する（startTimer は 1000ms）
+          window.__intervalMs = []
+          const orig = window.setInterval
+          window.setInterval = function (fn, ms, ...rest) {
+            window.__intervalMs.push(ms)
+            return orig.call(window, fn, ms, ...rest)
+          }
+
+          controller.startButtonTarget.click()
+          setTimeout(() => controller.startButtonTarget.click(), 200)
+        JS
+
+        # 遅延が明けてタイマーが動き出したことを、残り時間が減ることで確認する
+        expect(page).to have_content("00:59", wait: 10)
+
+        # startTimer() 由来（1 秒間隔）の interval が 1 本だけであること。
+        # 2 本作られると片方が this.timerInterval の上書きで参照を失い、
+        # 二度と clearInterval できなくなる（#265）
+        expect(page.evaluate_script("window.__intervalMs.filter(ms => ms === 1000).length")).to eq(1)
+      end
     end
 
     context "作業時間が終了したとき" do

--- a/spec/system/timer_exclusion_spec.rb
+++ b/spec/system/timer_exclusion_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe "タイマーの排他制御", type: :system do
       visit pomodoro_timer_activity_records_path
       click_button "スタート"
 
-      # リースが書き込まれるのを待つ
-      expect(page).to have_css("[data-pomodoro-target='startButton'].hidden", visible: :all)
+      # リースが書き込まれるのを待つ。startButton の hidden は「押した」だけを表し、
+      # リース取得は fetch の往復後なので同期ポイントにならない。
+      # 「終了する」の表示は startActivityLock() の直後なので、これを待つ。
+      expect(page).to have_button("終了する", visible: true)
 
       new_window = open_new_window
       within_window new_window do
@@ -51,7 +53,8 @@ RSpec.describe "タイマーの排他制御", type: :system do
     it "別タブでポモドーロ画面を開こうとしてもマイページへ追い返されること（光の時間の活動は 1 つだけ）" do
       visit pomodoro_timer_activity_records_path
       click_button "スタート"
-      expect(page).to have_css("[data-pomodoro-target='startButton'].hidden", visible: :all)
+      # リースが書き込まれるのを待つ（同期ポイントの理由は上記コメント参照）
+      expect(page).to have_button("終了する", visible: true)
 
       new_window = open_new_window
       within_window new_window do
@@ -96,8 +99,8 @@ RSpec.describe "タイマーの排他制御", type: :system do
       within_window new_window do
         visit pomodoro_timer_activity_records_path
         click_button "スタート"
-        # リースが書き込まれるのを待つ
-        expect(page).to have_css("[data-pomodoro-target='startButton'].hidden", visible: :all)
+        # リースが書き込まれるのを待つ（同期ポイントの理由は上記コメント参照）
+        expect(page).to have_button("終了する", visible: true)
       end
 
       aggregate_failures do
@@ -130,6 +133,47 @@ RSpec.describe "タイマーの排他制御", type: :system do
   end
 
   # =========================================================
+  # スタート押下から fetch が返るまでの間に離脱したとき
+  # =========================================================
+  describe "浄化タイマーへの問い合わせ中にキャンセルで離脱したとき" do
+    let!(:purification_time) { create(:purification_time, :idle_with_time, user: user) }
+
+    # 「キャンセル」は Turbo Drive のリンク遷移なので document は作り直されず、
+    # disconnect() が済んだ後もスタート処理の Promise だけが再開する。そこで
+    # リースを張ってしまうと、片付ける者がいないまま heartbeat が回り続け、
+    # ユーザーは浄化タイマーへ二度と入れなくなる。
+    it "往復が明けてもリースが張られないこと" do
+      visit pomodoro_timer_activity_records_path
+
+      # 問い合わせを、テストから明示的に解決できる Promise に差し替える
+      page.execute_script(<<~JS)
+        const el = document.querySelector('[data-controller="pomodoro"]')
+        const controller = window.Stimulus.getControllerForElementAndIdentifier(el, 'pomodoro')
+        controller.isPurificationCounting = () => new Promise(r => { window.__resolvePurification = () => r(false) })
+        controller.startButtonTarget.click()
+      JS
+
+      # 往復が終わる前に離脱する（この時点ではまだ「キャンセル」が出ている）
+      click_on "キャンセル", visible: true
+      expect(page).to have_current_path(mypage_path, ignore_query: true)
+
+      # 遷移後に往復が明ける。window は Turbo 遷移でも作り直されないので Promise は生きている
+      page.execute_script("window.__resolvePurification()")
+
+      aggregate_failures do
+        expect(page.evaluate_script("localStorage.getItem('gtt:activity_lock')")).to be_nil
+
+        # 別タブから浄化タイマーへ入れること（リースが無いことの利用者から見た確認）
+        new_window = open_new_window
+        within_window new_window do
+          visit purification_time_path
+          expect(page).to have_current_path(purification_time_path)
+        end
+      end
+    end
+  end
+
+  # =========================================================
   # Turbo Drive 下での離脱（pagehide が発火しないケース）
   # =========================================================
   describe "活動記録フォームから Turbo 遷移で離脱したとき" do
@@ -138,7 +182,8 @@ RSpec.describe "タイマーの排他制御", type: :system do
     it "「記録しない」で離脱すると、猶予（5秒）経過後には別タブから浄化タイマーへ入れること" do
       visit pomodoro_timer_activity_records_path
       click_button "スタート", visible: true
-      expect(page).to have_css("[data-pomodoro-target='startButton'].hidden", visible: :all)
+      # リースが書き込まれるのを待つ（startButton の hidden では早すぎる）
+      expect(page).to have_button("終了する", visible: true)
 
       accept_confirm("終了してよろしいでしょうか？") do
         within('[data-pomodoro-target="workScreen"]') do


### PR DESCRIPTION
Closes #265

## 概要

ポモドーロタイマー画面で最初のスタートボタンを二度押しすると `setInterval` が 2 本走り、片方が参照を失って二度と止められなくなる不具合を修正する。

PR #264 のレビュー中に発見した既存バグで、同 PR が持ち込んだものではない。

## 原因

`start()` が `await` 中に再入可能だった。

```js
async start() {
  if (this.timerInterval) return        // 門番1: まだ null
  if (this.firstStartedAt === null) {   // 門番2: まだ null
    if (await this.isPurificationCounting()) { ... }   // ★ ここで制御を手放す
    this.firstStartedAt = new Date()    // 門番2を閉じるのは await の後
    ...
  }
  this.startTimer()                     // 門番1を閉じるのはさらに後
  this.startButtonTarget.classList.add("hidden")   // ボタンが隠れるのも最後
}
```

2 つのガードはどちらも `await` より前に評価されるのに、**両方の値が `await` の後にしか設定されない**。`startTimer()` は `this.timerInterval` を上書きするため、先に作られた 1 本は参照を失い、`clearInterval(this.timerInterval)` では届かなくなる。

## 症状（issue の当初の記述は誤りだったので訂正済み）

「1 回の作業で 2 カウント」にはならない。JavaScript は一度に 1 つの処理しか動かないため、先に発火した方の `onTimerComplete()` が `endedAt` を先へずらし、もう片方は発火しない。

実際は**休憩明けの「スタート待ち」状態**で現れる。`switchToWorkMode()` は次の締切を設定するだけで `startTimer()` を呼ばない（ユーザーがスタートを押すまで待つ設計）が、迷子の interval は生きているのでその締切に勝手に到達する。結果、**押していないのにポモドーロ数が増え、休憩画面に切り替わり、チャイムが鳴る**。これが延々と繰り返される。

本番は作業 25 分なので「席を外している間に勝手に増えていく」という見え方になる。

## 修正

### 1. 再入フラグで閉じる（correctness）

```js
if (this.timerInterval || this.starting) return
this.starting = true
```

issue では「`await` の前にボタンを隠す」案を推していたが、**表示だけに頼るのはやめた**。`.hidden` は Tailwind の CSS クラスなので、ビルド成果物が読み込まれない状況では効かず、再入が復活する。#268 で同じ性質を議論したばかりでもあるので、正しさは DOM の状態に依存しないフラグで担保する。

本体は `startSession()` に切り出し、`start()` は再入ガードだけを持つ形にした。

### 2. `await` の前にボタンを隠す（UX）

こちらも入れる。押しても画面が何も変わらないと「反応がない」と感じて押し直す動機になるため、**動機そのものを断つ**。フラグがレースを塞ぎ、この変更が二度押しを起こりにくくする、という役割分担である。

### 3. 離脱後に副作用を起こさない（レビュー指摘で追加）

`await` の往復中に「キャンセル」で離脱できる。これは Turbo Drive のリンク遷移なので document は作り直されず、`disconnect()` が済んだ後も**この Promise だけが再開する**。そのまま進むと `addBeforeUnloadListener()` と `startActivityLock()` が死んだコントローラ上で走り、**誰も片付けられない**。

結果は深刻で、離脱警告が出続けるうえ、リースの heartbeat が回り続けて**浄化タイマーへ二度と入れなくなる**（タブを閉じるまで）。`this.element.isConnected` で弾く。

これは本 PR 以前から存在した経路だが、同じ `await` の窓を触っている以上ここで塞ぐ。

### 4. 失敗時にスタートボタンを戻す（レビュー指摘で追加）

`startSession()` が想定外に失敗した場合、ボタンも無くタイマーも動いていない行き止まりになる。押す前の状態へ戻して再試行できるようにする。

## 検証

### 二重起動を防ぐ System Spec

`isPurificationCounting()` に 1 秒の遅延を挟み、その窓の中で 2 回クリックして、`startTimer()` 由来（1 秒間隔）の `setInterval` が 1 本だけであることを確認する。修正前に実行して `expected: 1 / got: 2` で落ちることを確認済み。

### 離脱後にリースを張らない System Spec

問い合わせをテストから解決できる Promise に差し替え、往復中に「キャンセル」で離脱してから解決させる。修正を外すと、**別タブが `/mypage?locked=activity` へ追い返される**（＝浄化タイマーに入れない）という利用者から見た症状そのもので落ちることを確認済み。

### ブラウザでの実測（issue #265 の手順）

`window.setInterval` を差し替えて実測した。

| | 修正前 | 修正後 |
|---|---|---|
| `startTimer` が作った interval | `[55, 57]` | **`[54]`** |
| 迷子（誰も参照していない） | `[55]` | **`[]`** |
| 迷子の heartbeat | `[54]` | **`[]`** |
| 2 回目の押下時点でボタンは隠れていたか | — | **`true`** |

`startActivityLock()` の heartbeat が漏れる副次的な問題も同時に解消している。

### spec の同期ポイントを直した（レビュー指摘）

`startButton` の `hidden` を `await` の前へ移したことで、これが「start() 完了」ではなく「押した」を表すようになった。リース取得を待っていた `timer_exclusion_spec` の 4 箇所は、CI 高負荷時にリース書き込み前へ進んで間欠失敗しうる状態だった。

`updateExitButtons(true)` は `startActivityLock()` の直後に走るので、**「終了する」の表示**を同期ポイントに変更した。`activity_records_spec` の 5 箇所も同様に直し、実装と食い違ったコメントも合わせている。

### テストスイート

| コマンド | 結果 |
|---|---|
| `bundle exec rspec` | 637 examples, 0 failures |
| `bin/rubocop` | 108 files, no offenses |

## 影響範囲

初回スタートのみ。2 セッション目以降の `start()` は `firstStartedAt` が非 `null` なので `await` を含むブロックに入らず、関数全体が同期的に走るため割り込みの余地がない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)